### PR TITLE
Send/recv buff alias problem

### DIFF
--- a/src/framework/domain/metadomain.cpp
+++ b/src/framework/domain/metadomain.cpp
@@ -390,7 +390,7 @@ namespace ntt {
 #if defined(MPI_ENABLED)
     auto dx_mins        = std::vector<real_t>(g_ndomains);
     dx_mins[g_mpi_rank] = dx_min;
-    MPI_Allgather(&dx_mins[g_mpi_rank],
+    MPI_Allgather(&dx_min,
                   1,
                   mpi::get_type<real_t>(),
                   dx_mins.data(),


### PR DESCRIPTION
This was less of a bug, and more of an unsafe code which was explicitly disallowed by MPICH (but not OpenMPI). Should be fixed now.

Per [MPI standard](https://www.mpi-forum.org/docs/mpi-3.1/mpi31-report.pdf#section.2.3)

![image](https://github.com/user-attachments/assets/8ac9bd88-e227-446d-a281-61a30c4905d4)
