### PR TITLE
Supported Problem Generators cleaned

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,6 @@
 [submodule "extern/adios2"]
 	path = extern/adios2
 	url = https://github.com/ornladios/ADIOS2.git
-	branch = master
 [submodule "extern/Kokkos"]
 	path = extern/Kokkos
 	url = https://github.com/kokkos/kokkos.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,11 +79,10 @@ set(BUILD_TESTING
     CACHE BOOL "Build tests")
 
 # ------------------------ Third-party dependencies ------------------------ #
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/kokkosConfig.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies.cmake)
 
-find_or_fetch_dependency(Kokkos FALSE)
-find_or_fetch_dependency(plog TRUE)
+find_or_fetch_dependency(Kokkos FALSE QUIET)
+find_or_fetch_dependency(plog TRUE QUIET)
 set(DEPENDENCIES Kokkos::kokkos)
 include_directories(${plog_SRC}/include)
 
@@ -92,14 +91,15 @@ set_precision(${precision})
 
 # MPI
 if(${mpi})
-  include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/MPIConfig.cmake)
+  find_or_fetch_dependency(MPI FALSE REQUIRED)
+  include_directories(${MPI_CXX_INCLUDE_PATH})
+  add_compile_options("-D MPI_ENABLED")
   set(DEPENDENCIES ${DEPENDENCIES} MPI::MPI_CXX)
 endif()
 
 # Output
 if(${output})
-  include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/adios2Config.cmake)
-  find_or_fetch_dependency(adios2 FALSE)
+  find_or_fetch_dependency(adios2 FALSE QUIET)
   if(NOT DEFINED ENV{HDF5_ROOT})
     if(DEFINED ENV{CONDA_PREFIX})
       execute_process(COMMAND bash -c "conda list | grep \"hdf5\" -q"
@@ -110,7 +110,7 @@ if(${output})
     endif()
   endif()
   find_package(HDF5 REQUIRED)
-
+  add_compile_options("-D OUTPUT_ENABLED")
   if(${mpi})
     set(DEPENDENCIES ${DEPENDENCIES} adios2::cxx11_mpi)
   else()
@@ -119,6 +119,13 @@ if(${output})
 endif()
 
 link_libraries(${DEPENDENCIES})
+
+get_cmake_property(all_vars VARIABLES)
+foreach(_var ${all_vars})
+  if(_var MATCHES "^Kokkos_.*")
+    message(STATUS "PRINTING ${_var}=${${_var}}")
+  endif()
+endforeach()
 
 if(TESTS)
   # ---------------------------------- Tests --------------------------------- #
@@ -129,7 +136,7 @@ elseif(BENCHMARK)
 else()
   # ----------------------------------- GUI ---------------------------------- #
   if(${gui})
-    find_or_fetch_dependency(nttiny FALSE)
+    find_or_fetch_dependency(nttiny FALSE QUIET)
   endif()
 
   # ------------------------------- Main source ------------------------------ #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,16 +100,6 @@ endif()
 # Output
 if(${output})
   find_or_fetch_dependency(adios2 FALSE QUIET)
-  if(NOT DEFINED ENV{HDF5_ROOT})
-    if(DEFINED ENV{CONDA_PREFIX})
-      execute_process(COMMAND bash -c "conda list | grep \"hdf5\" -q"
-                      RESULT_VARIABLE HDF5_INSTALLED)
-      if(HDF5_INSTALLED EQUAL 0)
-        set(HDF5_ROOT $ENV{CONDA_PREFIX})
-      endif()
-    endif()
-  endif()
-  find_package(HDF5 REQUIRED)
   add_compile_options("-D OUTPUT_ENABLED")
   if(${mpi})
     set(DEPENDENCIES ${DEPENDENCIES} adios2::cxx11_mpi)
@@ -119,13 +109,6 @@ if(${output})
 endif()
 
 link_libraries(${DEPENDENCIES})
-
-get_cmake_property(all_vars VARIABLES)
-foreach(_var ${all_vars})
-  if(_var MATCHES "^Kokkos_.*")
-    message(STATUS "PRINTING ${_var}=${${_var}}")
-  endif()
-endforeach()
 
 if(TESTS)
   # ---------------------------------- Tests --------------------------------- #

--- a/cmake/MPIConfig.cmake
+++ b/cmake/MPIConfig.cmake
@@ -1,4 +1,0 @@
-find_package(MPI REQUIRED)
-include_directories(${MPI_CXX_INCLUDE_PATH})
-add_compile_options("-D MPI_ENABLED")
-

--- a/cmake/adios2Config.cmake
+++ b/cmake/adios2Config.cmake
@@ -12,13 +12,17 @@ set(ADIOS2_USE_Fortran
     CACHE BOOL "Use Fortran for ADIOS2")
 
 # Format/compression support
-set(ADIOS2_USE_ZeroMQ
-    OFF
-    CACHE BOOL "Use ZeroMQ for ADIOS2")
+set(ADIOS2_USE_HDF5
+    ON
+    CACHE BOOL "Use HDF5 for ADIOS2")
 
 set(ADIOS2_USE_MPI
     ${mpi}
     CACHE BOOL "Use MPI for ADIOS2")
+
+set(ADIOS2_USE_ZeroMQ
+    OFF
+    CACHE BOOL "Use ZeroMQ for ADIOS2")
 
 set(ADIOS2_USE_CUDA
     OFF

--- a/cmake/adios2Config.cmake
+++ b/cmake/adios2Config.cmake
@@ -23,5 +23,3 @@ set(ADIOS2_USE_MPI
 set(ADIOS2_USE_CUDA
     OFF
     CACHE BOOL "Use CUDA for ADIOS2")
-
-add_compile_options("-D OUTPUT_ENABLED")

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -34,13 +34,10 @@ function(set_problem_generator pgen_name)
     )
   endif()
   set(PGEN
-      ${pgen_name}
-      PARENT_SCOPE)
+      ${pgen_name} PARENT_SCOPE)
   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/setups/${pgen_name})
   set(PGEN_FOUND
-      TRUE
-      PARENT_SCOPE)
+      TRUE PARENT_SCOPE)
   set(problem_generators
-      ${PGEN_NAMES}
-      PARENT_SCOPE)
+      ${PGEN_NAMES} PARENT_SCOPE)
 endfunction()

--- a/cmake/defaults.cmake
+++ b/cmake/defaults.cmake
@@ -51,42 +51,6 @@ endif()
 
 set_property(CACHE default_gui PROPERTY TYPE BOOL)
 
-if(DEFINED ENV{Kokkos_ENABLE_CUDA})
-  set(default_KOKKOS_ENABLE_CUDA
-      $ENV{Kokkos_ENABLE_CUDA}
-      CACHE INTERNAL "Default flag for CUDA")
-else()
-  set(default_KOKKOS_ENABLE_CUDA
-      OFF
-      CACHE INTERNAL "Default flag for CUDA")
-endif()
-
-set_property(CACHE default_KOKKOS_ENABLE_CUDA PROPERTY TYPE BOOL)
-
-if(DEFINED ENV{Kokkos_ENABLE_HIP})
-  set(default_KOKKOS_ENABLE_HIP
-      $ENV{Kokkos_ENABLE_HIP}
-      CACHE INTERNAL "Default flag for HIP")
-else()
-  set(default_KOKKOS_ENABLE_HIP
-      OFF
-      CACHE INTERNAL "Default flag for HIP")
-endif()
-
-set_property(CACHE default_KOKKOS_ENABLE_HIP PROPERTY TYPE BOOL)
-
-if(DEFINED ENV{Kokkos_ENABLE_OPENMP})
-  set(default_KOKKOS_ENABLE_OPENMP
-      $ENV{Kokkos_ENABLE_OPENMP}
-      CACHE INTERNAL "Default flag for OpenMP")
-else()
-  set(default_KOKKOS_ENABLE_OPENMP
-      OFF
-      CACHE INTERNAL "Default flag for OpenMP")
-endif()
-
-set_property(CACHE default_KOKKOS_ENABLE_OPENMP PROPERTY TYPE BOOL)
-
 if(DEFINED ENV{Entity_ENABLE_MPI})
   set(default_mpi
       $ENV{Entity_ENABLE_MPI}

--- a/cmake/defaults.cmake
+++ b/cmake/defaults.cmake
@@ -33,7 +33,7 @@ if(DEFINED ENV{Entity_ENABLE_OUTPUT})
       CACHE INTERNAL "Default flag for output")
 else()
   set(default_output
-      OFF
+      ON
       CACHE INTERNAL "Default flag for output")
 endif()
 

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -4,9 +4,10 @@ set(Kokkos_REPOSITORY
 set(plog_REPOSITORY
     https://github.com/SergiusTheBest/plog.git
     CACHE STRING "plog repository")
+set (adios2_REPOSITORY
+    https://github.com/ornladios/ADIOS2.git
+    CACHE STRING "ADIOS2 repository")
 
-# set (adios2_REPOSITORY https://github.com/ornladios/ADIOS2.git CACHE STRING
-# "ADIOS2 repository")
 function(check_internet_connection)
   if(OFFLINE STREQUAL "ON")
     set(FETCHCONTENT_FULLY_DISCONNECTED
@@ -41,9 +42,9 @@ function(find_or_fetch_dependency package_name header_only mode)
 
   if(NOT ${package_name}_FOUND)
     if (${package_name} STREQUAL "Kokkos")
-      include(${CMAKE_CURRENT_SOURCE_DIR}/kokkosConfig.cmake)
+      include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/kokkosConfig.cmake)
     elseif(${package_name} STREQUAL "adios2")
-      include(${CMAKE_CURRENT_SOURCE_DIR}/adios2Config.cmake)
+      include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/adios2Config.cmake)
     endif()
     if(DEFINED ${package_name}_REPOSITORY AND NOT
                                               FETCHCONTENT_FULLY_DISCONNECTED)
@@ -70,6 +71,9 @@ function(find_or_fetch_dependency package_name header_only mode)
       set(${package_name}_SRC
           ${CMAKE_CURRENT_BINARY_DIR}/_deps/${lower_pckg_name}-src
           CACHE PATH "Path to ${package_name} src")
+      set(${package_name}_BUILD_DIR
+          ${CMAKE_CURRENT_BINARY_DIR}/_deps/${lower_pckg_name}-build
+          CACHE PATH "Path to ${package_name} build")
       set(${package_name}_FETCHED
           TRUE
           CACHE BOOL "Whether ${package_name} was fetched")
@@ -96,7 +100,7 @@ function(find_or_fetch_dependency package_name header_only mode)
       endif()
 
       add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extern/${package_name}
-                       extern/${package_name})
+                        extern/${package_name})
       set(${package_name}_SRC
           ${CMAKE_CURRENT_SOURCE_DIR}/extern/${package_name}
           CACHE PATH "Path to ${package_name} src")
@@ -132,7 +136,24 @@ function(find_or_fetch_dependency package_name header_only mode)
           ${Kokkos_VERSION}
           CACHE INTERNAL "Kokkos version")
     endif()
+    if(NOT DEFINED Kokkos_ARCH OR Kokkos_ARCH STREQUAL ""
+      OR NOT DEFINED Kokkos_DEVICES OR Kokkos_DEVICES STREQUAL "")
+      if(${Kokkos_FOUND})
+        include(${Kokkos_DIR}/KokkosConfigCommon.cmake)
+      elseif(NOT ${Kokkos_BUILD_DIR} STREQUAL "")
+        include(${Kokkos_BUILD_DIR}/KokkosConfigCommon.cmake)
+      else()
+        message(STATUS "${Red}Kokkos_DIR and Kokkos_BUILD_DIR not set.${ColorReset}")
+      endif()
+    endif()
+    set(Kokkos_ARCH
+        ${Kokkos_ARCH} PARENT_SCOPE)
+    set(Kokkos_DEVICES
+        ${Kokkos_DEVICES} PARENT_SCOPE)
   endif()
+  set(${package_name}_FOUND ${${package_name}_FOUND} PARENT_SCOPE)
+  set(${package_name}_FETCHED ${${package_name}_FETCHED} PARENT_SCOPE)
+  set(${package_name}_BUILD_DIR ${${package_name}_BUILD_DIR} PARENT_SCOPE)
 endfunction()
 
 check_internet_connection()

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -34,12 +34,17 @@ function(check_internet_connection)
   endif()
 endfunction()
 
-function(find_or_fetch_dependency package_name header_only)
+function(find_or_fetch_dependency package_name header_only mode)
   if(NOT header_only)
-    find_package(${package_name} QUIET)
+    find_package(${package_name} ${mode})
   endif()
 
   if(NOT ${package_name}_FOUND)
+    if (${package_name} STREQUAL "Kokkos")
+      include(${CMAKE_CURRENT_SOURCE_DIR}/kokkosConfig.cmake)
+    elseif(${package_name} STREQUAL "adios2")
+      include(${CMAKE_CURRENT_SOURCE_DIR}/adios2Config.cmake)
+    endif()
     if(DEFINED ${package_name}_REPOSITORY AND NOT
                                               FETCHCONTENT_FULLY_DISCONNECTED)
       # fetching package
@@ -52,7 +57,7 @@ function(find_or_fetch_dependency package_name header_only)
         FetchContent_Declare(
           ${package_name}
           GIT_REPOSITORY ${${package_name}_REPOSITORY}
-          GIT_TAG 4.3.00)
+          GIT_TAG 4.5.01)
       else()
         FetchContent_Declare(${package_name}
                              GIT_REPOSITORY ${${package_name}_REPOSITORY})

--- a/cmake/kokkosConfig.cmake
+++ b/cmake/kokkosConfig.cmake
@@ -27,51 +27,6 @@ else()
       CACHE BOOL "Kokkos debug bounds check")
 endif()
 
-set(Kokkos_ENABLE_HIP
-    ${default_KOKKOS_ENABLE_HIP}
-    CACHE BOOL "Enable HIP")
-set(Kokkos_ENABLE_CUDA
-    ${default_KOKKOS_ENABLE_CUDA}
-    CACHE BOOL "Enable CUDA")
-set(Kokkos_ENABLE_OPENMP
-    ${default_KOKKOS_ENABLE_OPENMP}
-    CACHE BOOL "Enable OpenMP")
-
-# set memory space
-if(${Kokkos_ENABLE_CUDA})
-  add_compile_definitions(CUDA_ENABLED)
-  set(ACC_MEM_SPACE Kokkos::CudaSpace)
-elseif(${Kokkos_ENABLE_HIP})
-  add_compile_definitions(HIP_ENABLED)
-  set(ACC_MEM_SPACE Kokkos::HIPSpace)
-else()
-  set(ACC_MEM_SPACE Kokkos::HostSpace)
-endif()
-
-set(HOST_MEM_SPACE Kokkos::HostSpace)
-
-# set execution space
-if(${Kokkos_ENABLE_CUDA})
-  set(ACC_EXE_SPACE Kokkos::Cuda)
-elseif(${Kokkos_ENABLE_HIP})
-  set(ACC_EXE_SPACE Kokkos::HIP)
-elseif(${Kokkos_ENABLE_OPENMP})
-  set(ACC_EXE_SPACE Kokkos::OpenMP)
-else()
-  set(ACC_EXE_SPACE Kokkos::Serial)
-endif()
-
-if(${Kokkos_ENABLE_OPENMP})
-  set(HOST_EXE_SPACE Kokkos::OpenMP)
-else()
-  set(HOST_EXE_SPACE Kokkos::Serial)
-endif()
-
-add_compile_options("-D AccelExeSpace=${ACC_EXE_SPACE}")
-add_compile_options("-D AccelMemSpace=${ACC_MEM_SPACE}")
-add_compile_options("-D HostExeSpace=${HOST_EXE_SPACE}")
-add_compile_options("-D HostMemSpace=${HOST_MEM_SPACE}")
-
 if(${BUILD_TESTING} STREQUAL "OFF")
   set(Kokkos_ENABLE_TESTS
       OFF

--- a/cmake/report.cmake
+++ b/cmake/report.cmake
@@ -1,95 +1,3 @@
-function(PadTo Text Padding Target Result)
-  set(rt ${Text})
-  string(FIND ${rt} "${Magenta}" mg_fnd)
-
-  if(mg_fnd GREATER -1)
-    string(REGEX REPLACE "${Esc}\\[35m" "" rt ${rt})
-  endif()
-
-  string(LENGTH "${rt}" TextLength)
-  math(EXPR PaddingNeeded "${Target} - ${TextLength}")
-  set(rt ${Text})
-
-  if(PaddingNeeded GREATER 0)
-    foreach(i RANGE 0 ${PaddingNeeded})
-      set(rt "${rt}${Padding}")
-    endforeach()
-  else()
-    set(${rt} "${rt}")
-  endif()
-
-  set(${Result}
-      "${rt}"
-      PARENT_SCOPE)
-endfunction()
-
-function(
-  PrintChoices
-  Label
-  Flag
-  Choices
-  Value
-  Default
-  Color
-  OutputString
-  Multiline
-  Padding)
-  list(LENGTH "${Choices}" nchoices)
-  set(rstring "")
-  set(counter 0)
-
-  foreach(ch ${Choices})
-    if(${counter} EQUAL 0)
-      set(rstring_i "- ${Label}")
-
-      if(NOT "${Flag}" STREQUAL "")
-        set(rstring_i "${rstring_i} [${Magenta}${Flag}${ColorReset}]")
-      endif()
-
-      set(rstring_i "${rstring_i}:")
-      padto("${rstring_i}" " " ${Padding} rstring_i)
-    else()
-      set(rstring_i "")
-
-      if(NOT ${counter} EQUAL ${nchoices})
-        if(${Multiline} EQUAL 1)
-          set(rstring_i "${rstring_i}\n")
-          padto("${rstring_i}" " " ${Padding} rstring_i)
-        else()
-          set(rstring_i "${rstring_i}/")
-        endif()
-      endif()
-    endif()
-
-    if(${ch} STREQUAL ${Value})
-      if(${ch} STREQUAL "ON")
-        set(col ${Green})
-      elseif(${ch} STREQUAL "OFF")
-        set(col ${Red})
-      else()
-        set(col ${Color})
-      endif()
-    else()
-      set(col ${Dim})
-    endif()
-
-    if(${ch} STREQUAL ${Default})
-      set(col ${Underline}${col})
-    endif()
-
-    set(rstring_i "${rstring_i}${col}${ch}${ColorReset}")
-    math(EXPR counter "${counter} + 1")
-    set(rstring "${rstring}${rstring_i}")
-    set(rstring_i "")
-  endforeach()
-
-  set(${OutputString}
-      "${rstring}"
-      PARENT_SCOPE)
-endfunction()
-
-set(ON_OFF_VALUES "ON" "OFF")
-
 if(${PGEN_FOUND})
   printchoices(
     "Problem generator"
@@ -99,8 +7,7 @@ if(${PGEN_FOUND})
     ${default_pgen}
     "${Blue}"
     PGEN_REPORT
-    1
-    36)
+    0)
 endif()
 
 printchoices(
@@ -111,7 +18,6 @@ printchoices(
   ${default_precision}
   "${Blue}"
   PRECISION_REPORT
-  1
   36)
 printchoices(
   "Output"
@@ -121,17 +27,6 @@ printchoices(
   ${default_output}
   "${Green}"
   OUTPUT_REPORT
-  0
-  36)
-printchoices(
-  "GUI"
-  "gui"
-  "${ON_OFF_VALUES}"
-  ${gui}
-  ${default_gui}
-  "${Green}"
-  GUI_REPORT
-  0
   36)
 printchoices(
   "MPI"
@@ -141,8 +36,7 @@ printchoices(
   OFF
   "${Green}"
   MPI_REPORT
-  0
-  42)
+  36)
 printchoices(
   "Debug mode"
   "DEBUG"
@@ -151,131 +45,7 @@ printchoices(
   OFF
   "${Green}"
   DEBUG_REPORT
-  0
-  42)
-
-printchoices(
-  "CUDA"
-  "Kokkos_ENABLE_CUDA"
-  "${ON_OFF_VALUES}"
-  ${Kokkos_ENABLE_CUDA}
-  "OFF"
-  "${Green}"
-  CUDA_REPORT
-  0
-  42)
-printchoices(
-  "HIP"
-  "Kokkos_ENABLE_HIP"
-  "${ON_OFF_VALUES}"
-  ${Kokkos_ENABLE_HIP}
-  "OFF"
-  "${Green}"
-  HIP_REPORT
-  0
-  42)
-printchoices(
-  "OpenMP"
-  "Kokkos_ENABLE_OPENMP"
-  "${ON_OFF_VALUES}"
-  ${Kokkos_ENABLE_OPENMP}
-  "OFF"
-  "${Green}"
-  OPENMP_REPORT
-  0
-  42)
-
-printchoices(
-  "C++ compiler"
-  "CMAKE_CXX_COMPILER"
-  "${CMAKE_CXX_COMPILER} v${CMAKE_CXX_COMPILER_VERSION}"
-  "${CMAKE_CXX_COMPILER} v${CMAKE_CXX_COMPILER_VERSION}"
-  "N/A"
-  "${ColorReset}"
-  CXX_COMPILER_REPORT
-  0
-  42)
-
-printchoices(
-  "C compiler"
-  "CMAKE_C_COMPILER"
-  "${CMAKE_C_COMPILER} v${CMAKE_C_COMPILER_VERSION}"
-  "${CMAKE_C_COMPILER} v${CMAKE_C_COMPILER_VERSION}"
-  "N/A"
-  "${ColorReset}"
-  C_COMPILER_REPORT
-  0
-  42)
-
-get_cmake_property(_variableNames VARIABLES)
-foreach(_variableName ${_variableNames})
-  string(REGEX MATCH "Kokkos_ARCH_*" _isMatched ${_variableName})
-  if(_isMatched)
-    get_property(
-      isSet
-      CACHE ${_variableName}
-      PROPERTY VALUE)
-    if(isSet STREQUAL "ON")
-      string(REGEX REPLACE "Kokkos_ARCH_" "" ARCH ${_variableName})
-      break()
-    endif()
-  endif()
-endforeach()
-printchoices(
-  "Architecture"
-  "Kokkos_ARCH_*"
-  "${ARCH}"
-  "${ARCH}"
-  "N/A"
-  "${ColorReset}"
-  ARCH_REPORT
-  0
-  42)
-
-if(${Kokkos_ENABLE_CUDA})
-  if("${CMAKE_CUDA_COMPILER}" STREQUAL "")
-    execute_process(COMMAND which nvcc OUTPUT_VARIABLE CUDACOMP)
-  else()
-    set(CUDACOMP ${CMAKE_CUDA_COMPILER})
-  endif()
-
-  string(STRIP ${CUDACOMP} CUDACOMP)
-
-  message(STATUS "CUDA compiler: ${CUDACOMP}")
-  execute_process(
-    COMMAND
-      bash -c
-      "${CUDACOMP} --version | grep release | sed -e 's/.*release //' -e 's/,.*//'"
-    OUTPUT_VARIABLE CUDACOMP_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-  printchoices(
-    "CUDA compiler"
-    "CMAKE_CUDA_COMPILER"
-    "${CUDACOMP}"
-    "${CUDACOMP}"
-    "N/A"
-    "${ColorReset}"
-    CUDA_COMPILER_REPORT
-    0
-    42)
-endif()
-
-if(${Kokkos_ENABLE_HIP})
-  execute_process(
-    COMMAND bash -c "hipcc --version | grep HIP | cut -d ':' -f 2 | tr -d ' '"
-    OUTPUT_VARIABLE ROCM_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif()
-
-set(DOT_SYMBOL "${ColorReset}.")
-set(DOTTED_LINE_SYMBOL
-    "${ColorReset}. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . "
-)
-
-set(DASHED_LINE_SYMBOL
-    "${ColorReset}....................................................................... "
-)
+  36)
 
 if(NOT ${PROJECT_VERSION_TWEAK} EQUAL 0)
   set(VERSION_SYMBOL
@@ -287,7 +57,7 @@ else()
   )
 endif()
 
-message(
+set(REPORT_TEXT
   "${Blue}              __        __
              /\\ \\__  __/\\ \\__
     __    ___\\ \\  _\\/\\_\\ \\  _\\  __  __
@@ -296,55 +66,107 @@ message(
  \\ \\____\\ \\_\\ \\_\\ \\__\\\\ \\_\\ \\__\\\\ \\____ \\/\\_\\
   \\/____/\\/_/\\/_/\\/__/ \\/_/\\/__/ \\/___/  \\/_/
                                     /\\___/
-Entity ${VERSION_SYMBOL}\t\t    \\/__/")
-message("${DASHED_LINE_SYMBOL}
-Main configurations")
+Entity ${VERSION_SYMBOL}\t\t    \\/__/"
+)
+string(APPEND REPORT_TEXT
+  ${ColorReset} "\n"
+)
+
+string(APPEND REPORT_TEXT
+  ${DASHED_LINE_SYMBOL} "\n"
+  "Configurations" "\n"
+)
 
 if(${PGEN_FOUND})
-  message("  ${PGEN_REPORT}")
+  string(APPEND REPORT_TEXT
+    "  " ${PGEN_REPORT} "\n"
+  )
 endif()
 
-message("  ${PRECISION_REPORT}")
-message("  ${OUTPUT_REPORT}")
-message("${DASHED_LINE_SYMBOL}\nCompile configurations")
+string(APPEND REPORT_TEXT
+  "  " ${PRECISION_REPORT} "\n"
+  "  " ${OUTPUT_REPORT} "\n"
+)
 
-if(NOT "${ARCH_REPORT}" STREQUAL "")
-  message("  ${ARCH_REPORT}")
+string(REPLACE ";" "+" Kokkos_ARCH "${Kokkos_ARCH}")
+string(REPLACE ";" "+" Kokkos_DEVICES "${Kokkos_DEVICES}")
+
+string(APPEND REPORT_TEXT
+  "  - ARCH [${Magenta}Kokkos_ARCH_***${ColorReset}]:         ${Kokkos_ARCH}" "\n"
+  "  - DEVICES [${Magenta}Kokkos_ENABLE_***${ColorReset}]:    ${Kokkos_DEVICES}" "\n"
+  "  " ${MPI_REPORT} "\n"
+  "  " ${DEBUG_REPORT} "\n"
+  ${DASHED_LINE_SYMBOL} "\n"
+  "Compilers & dependencies" "\n"
+)
+
+string(APPEND REPORT_TEXT
+  "  - C compiler [${Magenta}CMAKE_C_COMPILER${ColorReset}]: v" ${CMAKE_C_COMPILER_VERSION} "\n"
+  "    ${Dim}" ${CMAKE_C_COMPILER} "${ColorReset}\n"
+  "  - C++ compiler [${Magenta}CMAKE_CXX_COMPILER${ColorReset}]: v" ${CMAKE_CXX_COMPILER_VERSION} "\n"
+  "    ${Dim}" ${CMAKE_CXX_COMPILER} "${ColorReset}\n"
+)
+
+if(${Kokkos_DEVICES} MATCHES "CUDA")
+  if("${CMAKE_CUDA_COMPILER}" STREQUAL "")
+    execute_process(COMMAND which nvcc OUTPUT_VARIABLE CUDACOMP)
+  else()
+    set(CUDACOMP ${CMAKE_CUDA_COMPILER})
+  endif()
+  string(STRIP ${CUDACOMP} CUDACOMP)
+  execute_process(
+    COMMAND
+      bash -c
+      "${CUDACOMP} --version | grep release | sed -e 's/.*release //' -e 's/,.*//'"
+    OUTPUT_VARIABLE CUDACOMP_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(APPEND REPORT_TEXT
+    "  - CUDA compiler: v" ${CUDACOMP_VERSION} "\n"
+    "    ${Dim}" ${CUDACOMP} "${ColorReset}\n"
+  )
+elseif(${Kokkos_DEVICES} MATCHES "HIP")
+  execute_process(
+    COMMAND bash -c "hipcc --version | grep HIP | cut -d ':' -f 2 | tr -d ' '"
+    OUTPUT_VARIABLE ROCM_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(APPEND REPORT_TEXT
+    "  - ROCm: v" ${ROCM_VERSION} "\n"
+  )
 endif()
-message("  ${CUDA_REPORT}")
-message("  ${HIP_REPORT}")
-message("  ${OPENMP_REPORT}")
 
-message("  ${C_COMPILER_REPORT}")
-
-message("  ${CXX_COMPILER_REPORT}")
-
-if(NOT "${CUDA_COMPILER_REPORT}" STREQUAL "")
-  message("  ${CUDA_COMPILER_REPORT}")
+string(APPEND REPORT_TEXT
+  "  - Kokkos: v" ${Kokkos_VERSION} "\n"
+)
+if(${Kokkos_FOUND})
+  string(APPEND REPORT_TEXT
+    "    " ${Kokkos_DIR} "\n"
+  )
+else()
+  string(APPEND REPORT_TEXT
+    "    " ${Kokkos_BUILD_DIR} "\n"
+  )
 endif()
 
-message("  ${MPI_REPORT}")
-
-message("  ${DEBUG_REPORT}")
-
-message("${DASHED_LINE_SYMBOL}\nDependencies")
-
-if(NOT "${CUDACOMP_VERSION}" STREQUAL "")
-  message("  - CUDA:\tv${CUDACOMP_VERSION}")
-elseif(NOT "${ROCM_VERSION}" STREQUAL "")
-  message("  - ROCm:\tv${ROCM_VERSION}")
-endif()
-message("  - Kokkos:\tv${Kokkos_VERSION}")
 if(${output})
-  message("  - ADIOS2:\tv${adios2_VERSION}")
-endif()
-if(${HDF5_FOUND})
-  message("  - HDF5:\tv${HDF5_VERSION}")
+  string(APPEND REPORT_TEXT
+    "  - ADIOS2: v" ${adios2_VERSION} "\n"
+  )
+  if(${adios2_FOUND})
+    string(APPEND REPORT_TEXT
+      "    " ${adios2_DIR} "\n"
+    )
+  else()
+    string(APPEND REPORT_TEXT
+      "    " ${adios2_BUILD_DIR} "\n"
+    )
+  endif()
 endif()
 
-message(
-  "${DASHED_LINE_SYMBOL}
-Notes
-   ${Dim}: Set flags with `cmake ... -D ${Magenta}<FLAG>${ColorReset}${Dim}=<VALUE>`, the ${Underline}default${ColorReset}${Dim} value
-   :   will be used unless the variable is explicitly set.${ColorReset}
-")
+string(APPEND REPORT_TEXT
+  ${DASHED_LINE_SYMBOL} "\n"
+  "Notes" "\n"
+  "    ${Dim}: Set flags with `cmake ... -D ${Magenta}<FLAG>${ColorReset}${Dim}=<VALUE>`, the ${Underline}default${ColorReset}${Dim} value" "\n"
+  "    :   will be used unless the variable is explicitly set.${ColorReset}" "\n"
+)
+
+message(${REPORT_TEXT})

--- a/cmake/styling.cmake
+++ b/cmake/styling.cmake
@@ -23,17 +23,131 @@ if(NOT WIN32)
   set(StrikeEnd "${Esc}[0m")
 endif()
 
-# message("This is normal") message("${Red}This is Red${ColorReset}")
-# message("${Green}This is Green${ColorReset}") message("${Yellow}This is
-# Yellow${ColorReset}") message("${Blue}This is Blue${ColorReset}")
-# message("${Magenta}This is Magenta${ColorReset}") message("${Cyan}This is
-# Cyan${ColorReset}") message("${White}This is White${ColorReset}")
-# message("${BoldRed}This is BoldRed${ColorReset}") message("${BoldGreen}This is
-# BoldGreen${ColorReset}") message("${BoldYellow}This is
-# BoldYellow${ColorReset}") message("${BoldBlue}This is BoldBlue${ColorReset}")
-# message("${BoldMagenta}This is BoldMagenta${ColorReset}")
-# message("${BoldCyan}This is BoldCyan${ColorReset}") message("${BoldWhite}This
-# is BoldWhite\n\n${ColorReset}")
+set(DOTTED_LINE_SYMBOL
+    "${ColorReset}. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . "
+)
 
-# message()
+set(DASHED_LINE_SYMBOL
+    "${ColorReset}....................................................................... "
+)
 
+set(ON_OFF_VALUES "ON" "OFF")
+
+function(PureLength Text Result)
+  set(rt ${Text})
+  string(FIND ${rt} "${Magenta}" mg_fnd)
+
+  if(mg_fnd GREATER -1)
+    string(REGEX REPLACE "${Esc}\\[35m" "" rt ${rt})
+  endif()
+
+  string(LENGTH "${rt}" TextLength)
+  set(${Result}
+    "${TextLength}"
+    PARENT_SCOPE)
+endfunction()
+
+function(PadTo Text Padding Target Result)
+  purelength("${Text}" TextLength)
+  math(EXPR PaddingNeeded "${Target} - ${TextLength}")
+  set(rt ${Text})
+
+  if(PaddingNeeded GREATER 0)
+    foreach(i RANGE 0 ${PaddingNeeded})
+      set(rt "${rt}${Padding}")
+    endforeach()
+  else()
+    set(rt "${rt}")
+  endif()
+
+  set(${Result}
+      "${rt}"
+      PARENT_SCOPE)
+endfunction()
+
+function(
+  PrintChoices
+  Label
+  Flag
+  Choices
+  Value
+  Default
+  Color
+  OutputString
+  Padding)
+  set(rstring "- ${Label}")
+
+  if(NOT "${Flag}" STREQUAL "")
+    string(APPEND rstring " [${Magenta}${Flag}${ColorReset}]")
+  endif()
+
+  string(APPEND rstring ":")
+
+  if(${Padding} EQUAL 0)
+    list(LENGTH "${Choices}" nchoices)
+    math(EXPR lastchoice "${nchoices} - 1")
+    set(ncols 4)
+    math(EXPR lastcol "${ncols} - 1")
+
+    set(longest 0)
+    foreach(ch IN LISTS Choices)
+      string(LENGTH ${ch} clen)
+      if(clen GREATER longest)
+        set(longest ${clen})
+      endif()
+    endforeach()
+
+    set(counter 0)
+    foreach(ch IN LISTS Choices)
+      if(${ch} STREQUAL ${Value})
+        set(col ${Color})
+      else()
+        set(col ${Dim})
+      endif()
+
+      if(${ch} STREQUAL ${Default})
+        set(col ${Underline}${col})
+      endif()
+
+      string(LENGTH "${ch}" clen)
+      math(EXPR PaddingNeeded "${longest} - ${clen} + 4")
+
+      if(counter EQUAL ${lastcol} AND NOT ${counter} EQUAL ${lastchoice})
+        string(APPEND rstring "${col}~ ${ch}${ColorReset}")
+      else()
+        if(counter EQUAL 0)
+          string(APPEND rstring "\n    ")
+        endif()
+        string(APPEND rstring "${col}~ ${ch}${ColorReset}")
+        foreach(i RANGE 0 ${PaddingNeeded})
+          string(APPEND rstring " ")
+        endforeach()
+      endif()
+
+      math(EXPR counter "(${counter} + 1) % ${ncols}")
+    endforeach()
+  else()
+    padto("${rstring}" " " ${Padding} rstring)
+
+    set(new_choices ${Choices})
+    foreach(ch IN LISTS new_choices)
+      string(REPLACE ${ch} "${Dim}${ch}${ColorReset}" new_choices "${new_choices}")
+    endforeach()
+    set(Choices ${new_choices})
+    if(${Value} STREQUAL "ON")
+      set(col ${Green})
+    elseif(${Value} STREQUAL "OFF")
+      set(col ${Red})
+    else()
+      set(col ${Color})
+    endif()
+    string(REPLACE ${Value} "${col}${Value}${ColorReset}" Choices "${Choices}")
+    string(REPLACE ${Default} "${Underline}${Default}${ColorReset}" Choices "${Choices}")
+    string(REPLACE ";" "/" Choices "${Choices}")
+    string(APPEND rstring "${Choices}")
+  endif()
+
+  set(${OutputString}
+      "${rstring}"
+      PARENT_SCOPE)
+endfunction()

--- a/input.example.toml
+++ b/input.example.toml
@@ -107,11 +107,13 @@
     particles = ""
 
     [grid.boundaries.match]
-      # Size of the matching layer for fields in physical (code) units:
-      #   @type: float
+      # Size of the matching layer in each direction for fields in physical (code) units:
+      #   @type: float or array of tuples
       #   @default: 1% of the domain size (in shortest dimension)
       #   @note: In spherical, this is the size of the layer in r from the outer wall
-      #   @note: In cartesian, this is the same for all dimensions where applicable
+      #   @example: ds = 1.5 (will set the same for all directions)
+      #   @example: ds = [[1.5], [2.0, 1.0], [1.1]] (will duplicate 1.5 for +/- x1 and 1.1 for +/- x3)
+      #   @example: ds = [[], [1.5], []] (will only set for x2)
       ds = ""
       # Absorption coefficient for fields:
       #   @type: float: -inf < ... < inf, != 0

--- a/legacy/tests/kernels-gr.cpp
+++ b/legacy/tests/kernels-gr.cpp
@@ -1,15 +1,15 @@
-#include "wrapper.h"
-
 #include <Kokkos_Core.hpp>
 
 #include <iostream>
 #include <stdexcept>
 
+#include "wrapper.h"
+
 #include METRIC_HEADER
 
-#include "particle_macros.h"
-
 #include "kernels/particle_pusher_gr.hpp"
+
+#include "particle_macros.h"
 
 template <typename T>
 void put_value(ntt::array_t<T*>& arr, T value, int i) {
@@ -154,9 +154,10 @@ auto main(int argc, char* argv[]) -> int {
         static_cast<real_t>(1.0e-5),
         10,
         boundaries);
-      Kokkos::parallel_for("ParticlesPush",
-                           Kokkos::RangePolicy<AccelExeSpace, ntt::Massive_t>(0, 1),
-                           kernel);
+      Kokkos::parallel_for(
+        "ParticlesPush",
+        Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace, ntt::Massive_t>(0, 1),
+        kernel);
       auto [ra, tha]   = get_physical_coord(0, i1, i2, dx1, dx2, metric);
       const real_t pha = get_value(phi, 0);
 

--- a/legacy/tests/kernels-sr.cpp
+++ b/legacy/tests/kernels-sr.cpp
@@ -1,16 +1,16 @@
-#include "wrapper.h"
-
 #include <Kokkos_Core.hpp>
 
 #include <iostream>
 #include <stdexcept>
 
+#include "wrapper.h"
+
 #include METRIC_HEADER
 #include PGEN_HEADER
 
-#include "particle_macros.h"
-
 #include "kernels/particle_pusher_sr.hpp"
+
+#include "particle_macros.h"
 
 template <typename T>
 void put_value(ntt::array_t<T*>& arr, T value, int i) {
@@ -181,9 +181,10 @@ auto main(int argc, char* argv[]) -> int {
                                               ZERO,
                                               ZERO,
                                               ZERO);
-      Kokkos::parallel_for("ParticlesPush",
-                           Kokkos::RangePolicy<AccelExeSpace, ntt::Boris_t>(0, 1),
-                           kernel);
+      Kokkos::parallel_for(
+        "ParticlesPush",
+        Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace, ntt::Boris_t>(0, 1),
+        kernel);
       auto [xa, ya] = get_cartesian_coord(0, i1, i2, dx1, dx2, phi, metric);
 
       if (!ntt::AlmostEqual(xa,

--- a/setups/wip/reconnection/pgen.hpp
+++ b/setups/wip/reconnection/pgen.hpp
@@ -15,40 +15,135 @@
 #include "archetypes/spatial_dist.h"
 #include "framework/domain/metadomain.h"
 
+#include "kernels/particle_moments.hpp"
+
 namespace user {
   using namespace ntt;
 
   template <SimEngine::type S, class M>
   struct CurrentLayer : public arch::SpatialDistribution<S, M> {
-    CurrentLayer(const M& metric, real_t width, real_t yi)
+    CurrentLayer(const M& metric, real_t cs_width, real_t cs_y)
       : arch::SpatialDistribution<S, M> { metric }
-      , width { width }
-      , yi { yi } {}
+      , cs_width { cs_width }
+      , cs_y { cs_y } {}
 
     Inline auto operator()(const coord_t<M::Dim>& x_Ph) const -> real_t override {
-      return ONE / SQR(math::cosh((x_Ph[1] - yi) / width));
+      return ONE / SQR(math::cosh((x_Ph[1] - cs_y) / cs_width));
     }
 
   private:
-    const real_t yi, width;
+    const real_t cs_y, cs_width;
+  };
+
+  // field initializer
+  template <Dimension D>
+  struct InitFields {
+    InitFields(real_t bg_B, real_t bg_Bguide, real_t cs_width, real_t cs_y)
+      : bg_B { bg_B }
+      , bg_Bguide { bg_Bguide }
+      , cs_width { cs_width }
+      , cs_y { cs_y } {}
+
+    Inline auto bx1(const coord_t<D>& x_Ph) const -> real_t {
+      return bg_B * (math::tanh((x_Ph[1] - cs_y) / cs_width));
+    }
+
+    Inline auto bx3(const coord_t<D>&) const -> real_t {
+      return bg_Bguide;
+    }
+
+  private:
+    const real_t bg_B, bg_Bguide, cs_width, cs_y;
   };
 
   template <Dimension D>
-  struct InitFields {
-    InitFields(real_t Bmag, real_t width, real_t y1, real_t y2)
-      : Bmag { Bmag }
-      , width { width }
-      , y1 { y1 }
-      , y2 { y2 } {}
+  struct BoundaryFieldsInX1 {
+    BoundaryFieldsInX1(real_t bg_B,
+                       real_t bg_Bguide,
+                       real_t beta_rec,
+                       real_t cs_width,
+                       real_t cs_x,
+                       real_t cs_y)
+      : bg_B { bg_B }
+      , bg_Bguide { bg_Bguide }
+      , beta_rec { beta_rec }
+      , cs_width { cs_width }
+      , cs_x { cs_x }
+      , cs_y { cs_y } {}
 
     Inline auto bx1(const coord_t<D>& x_Ph) const -> real_t {
-      return Bmag * (math::tanh((x_Ph[1] - y1) / width) -
-                     math::tanh((x_Ph[1] - y2) / width) - 1);
+      return bg_B * (math::tanh((x_Ph[1] - cs_y) / cs_width));
+    }
+
+    Inline auto bx2(const coord_t<D>& x_Ph) const -> real_t {
+      return beta_rec * bg_B * (math::tanh((x_Ph[0] - cs_x) / cs_width));
+    }
+
+    Inline auto bx3(const coord_t<D>&) const -> real_t {
+      return bg_Bguide;
+    }
+
+    Inline auto ex1(const coord_t<D>& x_Ph) const -> real_t {
+      return beta_rec * bg_Bguide * math::tanh((x_Ph[1] - cs_y) / cs_width);
+    }
+
+    Inline auto ex2(const coord_t<D>&) const -> real_t {
+      return ZERO;
+    }
+
+    Inline auto ex3(const coord_t<D>&) const -> real_t {
+      return -beta_rec * bg_B;
     }
 
   private:
-    const real_t Bmag, width, y1, y2;
+    const real_t bg_B, bg_Bguide, beta_rec, cs_width, cs_x, cs_y;
   };
+
+  template <Dimension D>
+  struct BoundaryFieldsInX2 {
+    BoundaryFieldsInX2(real_t bg_B, real_t bg_Bguide, real_t cs_width, real_t cs_y)
+      : bg_B { bg_B }
+      , bg_Bguide { bg_Bguide }
+      , cs_width { cs_width }
+      , cs_y { cs_y } {}
+
+    Inline auto bx1(const coord_t<D>& x_Ph) const -> real_t {
+      return bg_B * (math::tanh((x_Ph[1] - cs_y) / cs_width));
+    }
+
+    Inline auto bx2(const coord_t<D>&) const -> real_t {
+      return ZERO;
+    }
+
+    Inline auto bx3(const coord_t<D>&) const -> real_t {
+      return bg_Bguide;
+    }
+
+    Inline auto ex1(const coord_t<D>&) const -> real_t {
+      return ZERO;
+    }
+
+    Inline auto ex2(const coord_t<D>&) const -> real_t {
+      return ZERO;
+    }
+
+    Inline auto ex3(const coord_t<D>&) const -> real_t {
+      return ZERO;
+    }
+
+  private:
+    const real_t bg_B, bg_Bguide, cs_width, cs_y;
+  };
+
+  // constant particle density for particle boundaries
+  template <SimEngine::type S, class M>
+  struct ConstDens {
+    Inline auto operator()(const coord_t<M::Dim>& x_Ph) const -> real_t {
+      return ONE;
+    }
+  };
+  template <SimEngine::type S, class M>
+  using spatial_dist_t = arch::Replenish<S, M, ConstDens<S, M>>;
 
   template <SimEngine::type S, class M>
   struct PGen : public arch::ProblemGenerator<S, M> {
@@ -64,30 +159,42 @@ namespace user {
     using arch::ProblemGenerator<S, M>::C;
     using arch::ProblemGenerator<S, M>::params;
 
-    const real_t  Bmag, width, overdensity, y1, y2, bg_temp;
+    const real_t bg_B, bg_Bguide, bg_temperature;
+    const real_t cs_width, cs_overdensity, cs_x, cs_y;
+
     InitFields<D> init_flds;
 
     inline PGen(const SimulationParams& p, const Metadomain<S, M>& m)
       : arch::ProblemGenerator<S, M>(p)
-      , Bmag { p.template get<real_t>("setup.Bmag", 1.0) }
-      , width { p.template get<real_t>("setup.width") }
-      , overdensity { p.template get<real_t>("setup.overdensity") }
-      , y1 { m.mesh().extent(in::x2).first +
-             INV_4 *
-               (m.mesh().extent(in::x2).second - m.mesh().extent(in::x2).first) }
-      , y2 { m.mesh().extent(in::x2).first +
-             3 * INV_4 *
-               (m.mesh().extent(in::x2).second - m.mesh().extent(in::x2).first) }
-      , init_flds { Bmag, width, y1, y2 }
-      , bg_temp { p.template get<real_t>("setup.bg_temp") } {}
+      , bg_B { p.template get<real_t>("setup.bg_B", 1.0) }
+      , bg_Bguide { p.template get<real_t>("setup.bg_Bguide", 0.0) }
+      , bg_temperature { p.template get<real_t>("setup.bg_temperature", 0.001) }
+      , cs_width { p.template get<real_t>("setup.cs_width") }
+      , cs_overdensity { p.template get<real_t>("setup.cs_overdensity") }
+      , cs_x { m.mesh().extent(in::x1).first +
+               INV_2 * (m.mesh().extent(in::x1).second -
+                        m.mesh().extent(in::x1).first) }
+      , cs_y { m.mesh().extent(in::x2).first +
+               INV_2 * (m.mesh().extent(in::x2).second -
+                        m.mesh().extent(in::x2).first) }
+      , init_flds { bg_B, bg_Bguide, cs_width, cs_y } {}
 
     inline PGen() {}
+
+    auto MatchFieldsInX1(simtime_t) const -> BoundaryFieldsInX1<D> {
+      return BoundaryFieldsInX1<D> { bg_B,     bg_Bguide, (real_t)0.1,
+                                     cs_width, cs_x,      cs_y };
+    }
+
+    auto MatchFieldsInX2(simtime_t) const -> BoundaryFieldsInX2<D> {
+      return BoundaryFieldsInX2<D> { bg_B, bg_Bguide, cs_width, cs_y };
+    }
 
     inline void InitPrtls(Domain<S, M>& local_domain) {
       // background
       const auto energy_dist = arch::Maxwellian<S, M>(local_domain.mesh.metric,
                                                       local_domain.random_pool,
-                                                      bg_temp);
+                                                      bg_temperature);
       const auto injector    = arch::UniformInjector<S, M, arch::Maxwellian>(
         energy_dist,
         { 1, 2 });
@@ -95,46 +202,111 @@ namespace user {
         params,
         local_domain,
         injector,
-        HALF);
+        ONE);
 
       const auto sigma = params.template get<real_t>("scales.sigma0");
       const auto c_omp = params.template get<real_t>("scales.skindepth0");
-      const auto cs_drift_beta = math::sqrt(sigma) * c_omp / (width * overdensity);
+      const auto cs_drift_beta = math::sqrt(sigma) * c_omp /
+                                 (cs_width * cs_overdensity);
       const auto cs_drift_gamma = ONE / math::sqrt(ONE - SQR(cs_drift_beta));
       const auto cs_drift_u     = cs_drift_beta * cs_drift_gamma;
-      const auto cs_temp        = HALF * sigma / overdensity;
-      // current layer #1
-      auto       edist_cs_1 = arch::Maxwellian<S, M>(local_domain.mesh.metric,
-                                               local_domain.random_pool,
-                                               cs_temp,
-                                               cs_drift_u,
-                                               in::x3,
-                                               false);
-      const auto sdist_cs_1 = CurrentLayer<S, M>(local_domain.mesh.metric, width, y1);
-      const auto inj_cs_1 = arch::NonUniformInjector<S, M, arch::Maxwellian, CurrentLayer>(
-        edist_cs_1,
-        sdist_cs_1,
+      const auto cs_temperature = HALF * sigma / cs_overdensity;
+
+      // current layer
+      auto       edist_cs = arch::Maxwellian<S, M>(local_domain.mesh.metric,
+                                             local_domain.random_pool,
+                                             cs_temperature,
+                                             cs_drift_u,
+                                             in::x3,
+                                             false);
+      const auto sdist_cs = CurrentLayer<S, M>(local_domain.mesh.metric,
+                                               cs_width,
+                                               cs_y);
+      const auto inj_cs = arch::NonUniformInjector<S, M, arch::Maxwellian, CurrentLayer>(
+        edist_cs,
+        sdist_cs,
         { 1, 2 });
-      arch::InjectNonUniform<S, M, decltype(inj_cs_1)>(params,
-                                                       local_domain,
-                                                       inj_cs_1,
-                                                       overdensity);
-      // current layer #2
-      const auto edist_cs_2 = arch::Maxwellian<S, M>(local_domain.mesh.metric,
-                                                     local_domain.random_pool,
-                                                     cs_temp,
-                                                     -cs_drift_u,
-                                                     in::x3,
-                                                     false);
-      const auto sdist_cs_2 = CurrentLayer<S, M>(local_domain.mesh.metric, width, y2);
-      const auto inj_cs_2 = arch::NonUniformInjector<S, M, arch::Maxwellian, CurrentLayer>(
-        edist_cs_2,
-        sdist_cs_2,
-        { 1, 2 });
-      arch::InjectNonUniform<S, M, decltype(inj_cs_2)>(params,
-                                                       local_domain,
-                                                       inj_cs_2,
-                                                       overdensity);
+      arch::InjectNonUniform<S, M, decltype(inj_cs)>(params,
+                                                     local_domain,
+                                                     inj_cs,
+                                                     cs_overdensity);
+    }
+
+    void CustomPostStep(std::size_t step, long double time, Domain<S, M>& domain) {
+      //       // 0. define target density profile and box where it has to be
+      //       reached
+      //       // 1. compute density
+      //       // 2. define spatial distribution
+      //       // 3. define energy distribution
+      //       // 4. define particle injector
+      //       // 5. inject particles
+      //
+      //       // step 0.
+      //       // defining the regions of interest (lower and upper
+      //       y-boundaries) boundaries_t<real_t> box_upper, box_lower; const
+      //       auto [xmin, xmax] = domain.mesh.extent(in::x1); const auto [ymin,
+      //       ymax] = domain.mesh.extent(in::x2); box_upper.push_back({ xmin,
+      //       xmax }); box_lower.push_back({ xmin, xmax });
+      //
+      //       box_upper.push_back({ ymax - dy, ymax });
+      //       box_lower.push_back({ ymin, ymin + dy });
+      //
+      //       if constexpr (M::Dim == Dim::_3D) {
+      //         const auto [zmin, zmax] = domain.mesh.extent(in::x3);
+      //         box_upper.push_back({ zmin, zmax });
+      //         box_lower.push_back({ zmin, zmax });
+      //       }
+      //
+      //       const auto const_dens = ConstDens<S, M>();
+      //       const auto inv_n0     = ONE / n0;
+      //
+      //       // step 1 compute density
+      //       auto scatter_bckp = Kokkos::Experimental::create_scatter_view(
+      //         domain.fields.bckp);
+      //       for (auto& prtl_spec : domain.species) {
+      //         // clang-format off
+      //         Kokkos::parallel_for(
+      //           "ComputeMoments",
+      //           prtl_spec.rangeActiveParticles(),
+      //           kernel::ParticleMoments_kernel<S, M, FldsID::N, 6>({},
+      //           scatter_bckp, 0,
+      //                                                     prtl_spec.i1,
+      //                                                     prtl_spec.i2,
+      //                                                     prtl_spec.i3, prtl_spec.dx1,
+      //                                                     prtl_spec.dx2,
+      //                                                     prtl_spec.dx3, prtl_spec.ux1,
+      //                                                     prtl_spec.ux2,
+      //                                                     prtl_spec.ux3, prtl_spec.phi,
+      //                                                     prtl_spec.weight,
+      //                                                     prtl_spec.tag, prtl_spec.mass(),
+      //                                                     prtl_spec.charge(),
+      //                                                     false,
+      //                                                     domain.mesh.metric,
+      //                                                     domain.mesh.flds_bc(),
+      //                                                     0, inv_n0, 0));
+      // 	}
+      // 	Kokkos::Experimental::contribute(domain.fields.bckp, scatter_bckp);
+      //
+      //
+      // 	//step 2. define spatial distribution
+      // //	const auto spatial_dist = arch::Replenish<S, M,
+      // user::ConstDens<S,M>>(domain.mesh.metric, domain.fields.bckp, 0,
+      // const_dens, ONE);
+      //   const auto spatial_dist = spatial_dist_t<S,M>(domain.mesh.metric,
+      //   domain.fields.bckp,0,const_dens,ONE);
+      // 	//step 3. define energy distribution
+      // 	const auto energy_dist = arch::Maxwellian<S, M>(domain.mesh.metric,
+      // domain.random_pool, up_temperature);
+      // 	//step 4. define particle injector
+      // 	const auto injector = arch::NonUniformInjector<S, M, arch::Maxwellian,
+      // spatial_dist_t>(energy_dist, spatial_dist, {1,2});
+      // 	//step 5. inject particles
+      // 	arch::InjectNonUniform<S, M, decltype(injector)>(params, domain,
+      // injector, ONE, false, box_upper); //upper boudary arch::InjectNonUniform<S,
+      // M, decltype(injector)>(params, domain, injector, ONE, false,
+      // box_lower); //lower boundary
+      //
+      //
     }
   };
 

--- a/setups/wip/reconnection/reconnection.toml
+++ b/setups/wip/reconnection/reconnection.toml
@@ -1,21 +1,21 @@
 [simulation]
-  name = "reconnection"
-  engine = "srpic"
+  name    = "reconnection"
+  engine  = "srpic"
   runtime = 10.0
 
 [grid]
-  resolution = [1024, 2048]
-  extent = [[-1.0, 1.0], [-2.0, 2.0]]
+  resolution = [1024, 512]
+  extent     = [[-1.0, 1.0], [-0.5, 0.5]]
 
   [grid.metric]
     metric = "minkowski"
 
   [grid.boundaries]
-    fields = [["PERIODIC"], ["PERIODIC"]]
-    particles = [["PERIODIC"], ["PERIODIC"]]
-    
+    fields    = [["MATCH", "MATCH"], ["MATCH", "MATCH"], ["PERIODIC"]]
+    particles = [["ABSORB", "ABSORB"], ["ABSORB", "ABSORB"], ["PERIODIC"]]
+
 [scales]
-  larmor0 = 2e-4
+  larmor0    = 2e-4
   skindepth0 = 2e-3
 
 [algorithms]
@@ -25,28 +25,28 @@
     CFL = 0.5
 
 [particles]
-  ppc0 = 8.0
+  ppc0 = 2.0
 
   [[particles.species]]
-    label = "e-"
-    mass = 1.0
-    charge = -1.0
+    label    = "e-"
+    mass     = 1.0
+    charge   = -1.0
     maxnpart = 1e7
 
   [[particles.species]]
-    label = "e+"
-    mass = 1.0
-    charge = 1.0
+    label    = "e+"
+    mass     = 1.0
+    charge   = 1.0
     maxnpart = 1e7
 
 [setup]
-  Bmag = 1.0
-  width = 0.01
-  bg_temp = 1e-4
+  Bmag        = 1.0
+  width       = 0.01
+  bg_temp     = 1e-4
   overdensity = 3.0
-  
+
 [output]
-  format = "hdf5"
+  format        = "hdf5"
   interval_time = 0.1
 
   [output.fields]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,6 @@
 #
 # * kokkos [required]
 # * plog [required]
-# * toml11 [required]
 # * ADIOS2 [optional]
 # * mpi [optional]
 # ------------------------------

--- a/src/archetypes/particle_injector.h
+++ b/src/archetypes/particle_injector.h
@@ -32,6 +32,7 @@
 #include <Kokkos_Core.hpp>
 
 #include <map>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -58,14 +59,79 @@ namespace arch {
       , species { species } {}
 
     ~UniformInjector() = default;
+
+    auto ComputeNumInject(const Domain<S, M>&         domain,
+                          real_t                      ppc0,
+                          real_t                      number_density,
+                          const boundaries_t<real_t>& box) const
+      -> std::tuple<bool, npart_t, array_t<real_t*>, array_t<real_t*>> {
+      auto i_min = array_t<real_t*> { "i_min", M::Dim };
+      auto i_max = array_t<real_t*> { "i_max", M::Dim };
+
+      if (not domain.mesh.Intersects(box)) {
+        return { false, (npart_t)0, i_min, i_max };
+      }
+      tuple_t<ncells_t, M::Dim> range_min { 0 };
+      tuple_t<ncells_t, M::Dim> range_max { 0 };
+
+      boundaries_t<bool> incl_ghosts;
+      for (auto d { 0u }; d < M::Dim; ++d) {
+        incl_ghosts.push_back({ false, false });
+      }
+      const auto intersect_range = domain.mesh.ExtentToRange(box, incl_ghosts);
+
+      for (auto d { 0u }; d < M::Dim; ++d) {
+        range_min[d] = intersect_range[d].first;
+        range_max[d] = intersect_range[d].second;
+      }
+      ncells_t ncells = 1;
+      for (auto d = 0u; d < M::Dim; ++d) {
+        ncells *= (range_max[d] - range_min[d]);
+      }
+      const auto nparticles = static_cast<npart_t>(
+        (long double)(ppc0 * number_density * 0.5) * (long double)(ncells));
+
+      auto i_min_h = Kokkos::create_mirror_view(i_min);
+      auto i_max_h = Kokkos::create_mirror_view(i_max);
+      for (auto d = 0u; d < M::Dim; ++d) {
+        i_min_h(d) = (real_t)(range_min[d]);
+        i_max_h(d) = (real_t)(range_max[d]);
+      }
+      Kokkos::deep_copy(i_min, i_min_h);
+      Kokkos::deep_copy(i_max, i_max_h);
+      return { true, nparticles, i_min, i_max };
+    }
+  };
+
+  template <SimEngine::type S, class M, template <SimEngine::type, class> class ED>
+  struct KeepConstantInjector : UniformInjector<S, M, ED> {
+    using energy_dist_t = ED<S, M>;
+    using UniformInjector<S, M, ED>::D;
+    using UniformInjector<S, M, ED>::C;
+
+    const boundaries_t<real_t> probe_box;
+
+    KeepConstantInjector(const energy_dist_t&               energy_dist,
+                         const std::pair<spidx_t, spidx_t>& species,
+                         boundaries_t<real_t>               probe_box = {})
+      : UniformInjector<S, M, ED>(energy_dist, species)
+      , probe_box { probe_box } {}
+
+    ~KeepConstantInjector() = default;
+
+    auto ComputeNumInject(const Domain<S, M>&         domain,
+                          real_t                      ppc0,
+                          real_t                      number_density,
+                          const boundaries_t<real_t>& box) const
+      -> std::tuple<bool, npart_t, array_t<real_t*>, array_t<real_t*>> {
+      ...
+    }
   };
 
   template <SimEngine::type S,
             class M,
-            template <SimEngine::type, class>
-            class ED,
-            template <SimEngine::type, class>
-            class SD>
+            template <SimEngine::type, class> class ED,
+            template <SimEngine::type, class> class SD>
   struct NonUniformInjector {
     using energy_dist_t  = ED<S, M>;
     using spatial_dist_t = SD<S, M>;
@@ -181,11 +247,12 @@ namespace arch {
    * @tparam I Injector type
    */
   template <SimEngine::type S, class M, class I>
-  inline void InjectUniform(const SimulationParams& params,
-                            Domain<S, M>&           domain,
-                            const I&                injector,
-                            real_t                  number_density,
-                            bool                    use_weights = false) {
+  inline void InjectUniform(const SimulationParams&     params,
+                            Domain<S, M>&               domain,
+                            const I&                    injector,
+                            real_t                      number_density,
+                            bool                        use_weights = false,
+                            const boundaries_t<real_t>& box         = {}) {
     static_assert(M::is_metric, "M must be a metric class");
     static_assert(I::is_uniform_injector, "I must be a uniform injector class");
     raise::ErrorIf((M::CoordType != Coord::Cart) && (not use_weights),
@@ -205,17 +272,25 @@ namespace arch {
     }
 
     {
-      auto             ppc0 = params.template get<real_t>("particles.ppc0");
-      array_t<real_t*> ni { "ni", M::Dim };
-      auto             ni_h   = Kokkos::create_mirror_view(ni);
-      ncells_t         ncells = 1;
-      for (auto d = 0; d < M::Dim; ++d) {
-        ni_h(d)  = domain.mesh.n_active()[d];
-        ncells  *= domain.mesh.n_active()[d];
+      boundaries_t<real_t> nonempty_box;
+      for (auto d { 0u }; d < M::Dim; ++d) {
+        if (d < box.size()) {
+          nonempty_box.push_back({ box[d].first, box[d].second });
+        } else {
+          nonempty_box.push_back(Range::All);
+        }
       }
-      Kokkos::deep_copy(ni, ni_h);
-      const auto nparticles = static_cast<npart_t>(
-        (long double)(ppc0 * number_density * 0.5) * (long double)(ncells));
+      auto       ppc0   = params.template get<real_t>("particles.ppc0");
+      const auto result = injector.ComputeNumInject(domain,
+                                                    ppc0,
+                                                    number_density,
+                                                    nonempty_box);
+      if (not std::get<0>(result)) {
+        return;
+      }
+      const auto nparticles = std::get<1>(result);
+      const auto i_min      = std::get<2>(result);
+      const auto i_max      = std::get<3>(result);
 
       Kokkos::parallel_for(
         "InjectUniform",
@@ -228,7 +303,8 @@ namespace arch {
           domain.species[injector.species.first - 1].npart(),
           domain.species[injector.species.second - 1].npart(),
           domain.mesh.metric,
-          ni,
+          i_min,
+          i_max,
           injector.energy_dist,
           ONE / params.template get<real_t>("scales.V0"),
           domain.random_pool));
@@ -279,12 +355,12 @@ namespace arch {
    * @param box Region to inject the particles in
    */
   template <SimEngine::type S, class M, class I>
-  inline void InjectNonUniform(const SimulationParams& params,
-                               Domain<S, M>&           domain,
-                               const I&                injector,
-                               real_t                  number_density,
-                               bool                    use_weights = false,
-                               boundaries_t<real_t>    box         = {}) {
+  inline void InjectNonUniform(const SimulationParams&     params,
+                               Domain<S, M>&               domain,
+                               const I&                    injector,
+                               real_t                      number_density,
+                               bool                        use_weights = false,
+                               const boundaries_t<real_t>& box         = {}) {
     static_assert(M::is_metric, "M must be a metric class");
     static_assert(I::is_nonuniform_injector,
                   "I must be a nonuniform injector class");

--- a/src/checkpoint/tests/checkpoint-mpi.cpp
+++ b/src/checkpoint/tests/checkpoint-mpi.cpp
@@ -144,8 +144,8 @@ auto main(int argc, char* argv[]) -> int {
       writer.saveField<Dim::_2D, 6>("em", field1);
       writer.saveField<Dim::_2D, 6>("em0", field2);
 
-      writer.savePerDomainVariable<std::size_t>("s1_npart", 1, 0, npart1);
-      writer.savePerDomainVariable<std::size_t>("s2_npart", 1, 0, npart2);
+      writer.savePerDomainVariable<npart_t>("s1_npart", 1, 0, npart1);
+      writer.savePerDomainVariable<npart_t>("s2_npart", 1, 0, npart2);
 
       writer.saveParticleQuantity<int>("s1_i1",
                                        npart1_globtot,

--- a/src/checkpoint/tests/checkpoint-nompi.cpp
+++ b/src/checkpoint/tests/checkpoint-nompi.cpp
@@ -105,8 +105,8 @@ auto main(int argc, char* argv[]) -> int {
       writer.saveField<Dim::_3D, 6>("em", field1);
       writer.saveField<Dim::_3D, 6>("em0", field2);
 
-      writer.savePerDomainVariable<std::size_t>("s1_npart", 1, 0, npart1);
-      writer.savePerDomainVariable<std::size_t>("s2_npart", 1, 0, npart2);
+      writer.savePerDomainVariable<npart_t>("s1_npart", 1, 0, npart1);
+      writer.savePerDomainVariable<npart_t>("s2_npart", 1, 0, npart2);
 
       writer.saveParticleQuantity<int>("s1_i1", npart1, 0, npart1, i1);
       writer.saveParticleQuantity<real_t>("s1_ux1", npart1, 0, npart1, u1);

--- a/src/checkpoint/writer.cpp
+++ b/src/checkpoint/writer.cpp
@@ -274,9 +274,9 @@ namespace checkpoint {
                                                       std::size_t,
                                                       double);
   template void Writer::savePerDomainVariable<npart_t>(const std::string&,
-                                                           std::size_t,
-                                                           std::size_t,
-                                                           npart_t);
+                                                       std::size_t,
+                                                       std::size_t,
+                                                       npart_t);
 
   template void Writer::saveField<Dim::_1D, 3>(const std::string&,
                                                const ndfield_t<Dim::_1D, 3>&);

--- a/src/engines/CMakeLists.txt
+++ b/src/engines/CMakeLists.txt
@@ -38,7 +38,7 @@ add_library(ntt_engines ${SOURCES})
 set(libs ntt_global ntt_framework ntt_metrics ntt_archetypes ntt_kernels
          ntt_pgen)
 if(${output})
-  list(APPEND libs ntt_output hdf5::hdf5)
+  list(APPEND libs ntt_output)
 endif()
 add_dependencies(ntt_engines ${libs})
 target_link_libraries(ntt_engines PUBLIC ${libs})

--- a/src/engines/CMakeLists.txt
+++ b/src/engines/CMakeLists.txt
@@ -25,7 +25,6 @@
 #
 # * kokkos [required]
 # * plog [required]
-# * toml11 [required]
 # * adios2 [optional]
 # * hdf5 [optional]
 # * mpi [optional]

--- a/src/engines/engine_printer.cpp
+++ b/src/engines/engine_printer.cpp
@@ -20,7 +20,6 @@
 #endif
 
 #if defined(OUTPUT_ENABLED)
-  #include <H5public.h>
   #include <adios2.h>
 #endif
 
@@ -188,18 +187,11 @@ namespace ntt {
                                                 KOKKOS_VERSION % 100);
 
 #if defined(OUTPUT_ENABLED)
-        unsigned h5_major, h5_minor, h5_release;
-        H5get_libversion(&h5_major, &h5_minor, &h5_release);
-        const std::string hdf5_version   = fmt::format("%d.%d.%d",
-                                                     h5_major,
-                                                     h5_minor,
-                                                     h5_release);
         const std::string adios2_version = fmt::format("%d.%d.%d",
                                                        ADIOS2_VERSION / 10000,
                                                        ADIOS2_VERSION / 100 % 100,
                                                        ADIOS2_VERSION % 100);
 #else // not OUTPUT_ENABLED
-        const std::string hdf5_version   = "OFF";
         const std::string adios2_version = "OFF";
 #endif
 
@@ -217,7 +209,6 @@ namespace ntt {
         add_param(report, 4, "CXX", "%s [%s]", ccx.c_str(), cpp_standard.c_str());
         add_param(report, 4, "CUDA", "%s", cuda_version.c_str());
         add_param(report, 4, "MPI", "%s", mpi_version.c_str());
-        add_param(report, 4, "HDF5", "%s", hdf5_version.c_str());
         add_param(report, 4, "Kokkos", "%s", kokkos_version.c_str());
         add_param(report, 4, "ADIOS2", "%s", adios2_version.c_str());
         add_param(report, 4, "Precision", "%s", precision);

--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -28,7 +28,6 @@
 #
 # * kokkos [required]
 # * plog [required]
-# * toml11 [required]
 # * ADIOS2 [optional]
 # * mpi [optional]
 # ------------------------------

--- a/src/framework/containers/particles.cpp
+++ b/src/framework/containers/particles.cpp
@@ -218,13 +218,13 @@ namespace ntt {
 
     Kokkos::Experimental::fill(
       "TagAliveParticles",
-      AccelExeSpace(),
+      Kokkos::DefaultExecutionSpace(),
       Kokkos::subview(this_tag, std::make_pair(static_cast<npart_t>(0), n_alive)),
       ParticleTag::alive);
 
     Kokkos::Experimental::fill(
       "TagDeadParticles",
-      AccelExeSpace(),
+      Kokkos::DefaultExecutionSpace(),
       Kokkos::subview(this_tag, std::make_pair(n_alive, n_alive + n_dead)),
       ParticleTag::dead);
 

--- a/src/framework/domain/comm_mpi.hpp
+++ b/src/framework/domain/comm_mpi.hpp
@@ -83,7 +83,7 @@ namespace comm {
                                  (long int)(send_slice[0].first);
           Kokkos::parallel_for(
             "CommunicateField-extract",
-            Kokkos::MDRangePolicy<Kokkos::Rank<2>, AccelExeSpace>(
+            Kokkos::MDRangePolicy<Kokkos::Rank<2>, Kokkos::DefaultExecutionSpace>(
               { recv_slice[0].first, comps.first },
               { recv_slice[0].second, comps.second }),
             Lambda(index_t i1, index_t ci) {
@@ -96,7 +96,7 @@ namespace comm {
                                  (long int)(send_slice[1].first);
           Kokkos::parallel_for(
             "CommunicateField-extract",
-            Kokkos::MDRangePolicy<Kokkos::Rank<3>, AccelExeSpace>(
+            Kokkos::MDRangePolicy<Kokkos::Rank<3>, Kokkos::DefaultExecutionSpace>(
               { recv_slice[0].first, recv_slice[1].first, comps.first },
               { recv_slice[0].second, recv_slice[1].second, comps.second }),
             Lambda(index_t i1, index_t i2, index_t ci) {
@@ -111,7 +111,7 @@ namespace comm {
                                  (long int)(send_slice[2].first);
           Kokkos::parallel_for(
             "CommunicateField-extract",
-            Kokkos::MDRangePolicy<Kokkos::Rank<4>, AccelExeSpace>(
+            Kokkos::MDRangePolicy<Kokkos::Rank<4>, Kokkos::DefaultExecutionSpace>(
               { recv_slice[0].first,
                 recv_slice[1].first,
                 recv_slice[2].first,
@@ -239,7 +239,7 @@ namespace comm {
             const auto offset_c  = comps.first;
             Kokkos::parallel_for(
               "CommunicateField-extract",
-              Kokkos::MDRangePolicy<Kokkos::Rank<2>, AccelExeSpace>(
+              Kokkos::MDRangePolicy<Kokkos::Rank<2>, Kokkos::DefaultExecutionSpace>(
                 { recv_slice[0].first, comps.first },
                 { recv_slice[0].second, comps.second }),
               Lambda(index_t i1, index_t ci) {
@@ -251,7 +251,7 @@ namespace comm {
             const auto offset_c  = comps.first;
             Kokkos::parallel_for(
               "CommunicateField-extract",
-              Kokkos::MDRangePolicy<Kokkos::Rank<3>, AccelExeSpace>(
+              Kokkos::MDRangePolicy<Kokkos::Rank<3>, Kokkos::DefaultExecutionSpace>(
                 { recv_slice[0].first, recv_slice[1].first, comps.first },
                 { recv_slice[0].second, recv_slice[1].second, comps.second }),
               Lambda(index_t i1, index_t i2, index_t ci) {
@@ -266,7 +266,7 @@ namespace comm {
             const auto offset_c  = comps.first;
             Kokkos::parallel_for(
               "CommunicateField-extract",
-              Kokkos::MDRangePolicy<Kokkos::Rank<4>, AccelExeSpace>(
+              Kokkos::MDRangePolicy<Kokkos::Rank<4>, Kokkos::DefaultExecutionSpace>(
                 { recv_slice[0].first,
                   recv_slice[1].first,
                   recv_slice[2].first,

--- a/src/framework/domain/comm_nompi.hpp
+++ b/src/framework/domain/comm_nompi.hpp
@@ -70,7 +70,7 @@ namespace comm {
                                  (long int)(send_slice[0].first);
           Kokkos::parallel_for(
             "CommunicateField-extract",
-            Kokkos::MDRangePolicy<Kokkos::Rank<2>, AccelExeSpace>(
+            Kokkos::MDRangePolicy<Kokkos::Rank<2>, Kokkos::DefaultExecutionSpace>(
               { recv_slice[0].first, comps.first },
               { recv_slice[0].second, comps.second }),
             Lambda(index_t i1, index_t ci) {
@@ -83,7 +83,7 @@ namespace comm {
                                  (long int)(send_slice[1].first);
           Kokkos::parallel_for(
             "CommunicateField-extract",
-            Kokkos::MDRangePolicy<Kokkos::Rank<3>, AccelExeSpace>(
+            Kokkos::MDRangePolicy<Kokkos::Rank<3>, Kokkos::DefaultExecutionSpace>(
               { recv_slice[0].first, recv_slice[1].first, comps.first },
               { recv_slice[0].second, recv_slice[1].second, comps.second }),
             Lambda(index_t i1, index_t i2, index_t ci) {
@@ -98,7 +98,7 @@ namespace comm {
                                  (long int)(send_slice[2].first);
           Kokkos::parallel_for(
             "CommunicateField-extract",
-            Kokkos::MDRangePolicy<Kokkos::Rank<4>, AccelExeSpace>(
+            Kokkos::MDRangePolicy<Kokkos::Rank<4>, Kokkos::DefaultExecutionSpace>(
               { recv_slice[0].first,
                 recv_slice[1].first,
                 recv_slice[2].first,

--- a/src/framework/domain/mesh.h
+++ b/src/framework/domain/mesh.h
@@ -74,7 +74,7 @@ namespace ntt {
      * @note pass Range::All to select the entire dimension
      */
     [[nodiscard]]
-    auto Intersection(boundaries_t<real_t> box) -> boundaries_t<real_t> {
+    auto Intersection(boundaries_t<real_t> box) const -> boundaries_t<real_t> {
       raise::ErrorIf(box.size() != M::Dim, "Invalid box dimension", HERE);
       boundaries_t<real_t> intersection;
       auto                 d = 0;
@@ -109,7 +109,7 @@ namespace ntt {
      * @note pass Range::All to select the entire dimension
      */
     [[nodiscard]]
-    auto Intersects(boundaries_t<real_t> box) -> bool {
+    auto Intersects(boundaries_t<real_t> box) const -> bool {
       raise::ErrorIf(box.size() != M::Dim, "Invalid box dimension", HERE);
       const auto intersection = Intersection(box);
       for (const auto& i : intersection) {
@@ -131,8 +131,8 @@ namespace ntt {
      * @note indices are already shifted by N_GHOSTS (i.e. they start at N_GHOSTS not 0)
      */
     [[nodiscard]]
-    auto ExtentToRange(boundaries_t<real_t> box,
-                       boundaries_t<bool> incl_ghosts) -> boundaries_t<ncells_t> {
+    auto ExtentToRange(boundaries_t<real_t> box, boundaries_t<bool> incl_ghosts) const
+      -> boundaries_t<ncells_t> {
       raise::ErrorIf(box.size() != M::Dim, "Invalid box dimension", HERE);
       raise::ErrorIf(incl_ghosts.size() != M::Dim,
                      "Invalid incl_ghosts dimension",

--- a/src/framework/parameters.cpp
+++ b/src/framework/parameters.cpp
@@ -31,10 +31,10 @@
 namespace ntt {
 
   template <typename M>
-  auto get_dx0_V0(
-    const std::vector<ncells_t>&         resolution,
-    const boundaries_t<real_t>&          extent,
-    const std::map<std::string, real_t>& params) -> std::pair<real_t, real_t> {
+  auto get_dx0_V0(const std::vector<ncells_t>&         resolution,
+                  const boundaries_t<real_t>&          extent,
+                  const std::map<std::string, real_t>& params)
+    -> std::pair<real_t, real_t> {
     const auto      metric = M(resolution, extent, params);
     const auto      dx0    = metric.dxMin();
     coord_t<M::Dim> x_corner { ZERO };
@@ -736,23 +736,63 @@ namespace ntt {
         for (const auto& e : extent_pairwise) {
           min_extent = std::min(min_extent, e.second - e.first);
         }
-        set("grid.boundaries.match.ds",
-            toml::find_or(toml_data,
-                          "grid",
-                          "boundaries",
-                          "match",
-                          "ds",
-                          min_extent * defaults::bc::match::ds_frac));
+        const auto  default_ds = min_extent * defaults::bc::match::ds_frac;
+        std::size_t n_match_bcs { 0u };
+        for (const auto& bcs : flds_bc_pairwise) {
+          if (bcs.first == FldsBC::MATCH or bcs.second == FldsBC::MATCH) {
+            n_match_bcs += 1;
+          }
+        }
+        boundaries_t<real_t> ds_array;
+        try {
+          auto ds = toml::find<real_t>(toml_data, "grid", "boundaries", "match", "ds");
+          for (auto d = 0u; d < dim; ++d) {
+            ds_array.push_back({ ds, ds });
+          }
+        } catch (const toml::type_error&) {
+          try {
+            const auto ds = toml::find<std::vector<std::vector<real_t>>>(
+              toml_data,
+              "grid",
+              "boundaries",
+              "match",
+              "ds");
+            raise::ErrorIf(ds.size() != dim,
+                           "invalid # in `grid.boundaries.match.ds`",
+                           HERE);
+            for (auto d = 0u; d < dim; ++d) {
+              if (ds[d].size() == 1) {
+                ds_array.push_back({ ds[d][0], ds[d][0] });
+              } else if (ds[d].size() == 2) {
+                ds_array.push_back({ ds[d][0], ds[d][1] });
+              } else if (ds[d].size() == 0) {
+                ds_array.push_back({});
+              } else {
+                raise::Error("invalid `grid.boundaries.match.ds`", HERE);
+              }
+            }
+          } catch (...) {
+            for (auto d = 0u; d < dim; ++d) {
+              ds_array.push_back({ default_ds, default_ds });
+            }
+          }
+        }
+        set("grid.boundaries.match.ds", ds_array);
       } else {
         auto r_extent = extent_pairwise[0].second - extent_pairwise[0].first;
-        set("grid.boundaries.match.ds",
-            toml::find_or(toml_data,
-                          "grid",
-                          "boundaries",
-                          "match",
-                          "ds",
-                          r_extent * defaults::bc::match::ds_frac));
+        const auto ds = toml::find_or<real_t>(
+          toml_data,
+          "grid",
+          "boundaries",
+          "match",
+          "ds",
+          r_extent * defaults::bc::match::ds_frac);
+        boundaries_t<real_t> ds_array {
+          { ds, ds }
+        };
+        set("grid.boundaries.match.ds", ds_array);
       }
+
       set("grid.boundaries.match.coeff",
           toml::find_or(toml_data,
                         "grid",

--- a/src/framework/tests/CMakeLists.txt
+++ b/src/framework/tests/CMakeLists.txt
@@ -5,7 +5,6 @@
 #
 # * kokkos [required]
 # * plog [required]
-# * toml11 [required]
 # * mpi [optional]
 # * adios2 [optional]
 #

--- a/src/framework/tests/parameters.cpp
+++ b/src/framework/tests/parameters.cpp
@@ -29,12 +29,12 @@ const auto mink_1d = u8R"(
     metric = "minkowski"
 
   [grid.boundaries]
-    fields = [["PERIODIC"]]
+    fields = [["MATCH", "MATCH"]]
     particles = [["ABSORB", "ABSORB"]]
 
     [grid.boundaries.match]
       coeff = 10.0
-      ds = 0.025
+      ds = [[0.025, 0.1]]
 
 [scales]
   larmor0 = 0.1
@@ -269,7 +269,7 @@ auto main(int argc, char* argv[]) -> int {
                    (real_t)0.0078125,
                    "scales.V0");
       boundaries_t<FldsBC> fbc = {
-        { FldsBC::PERIODIC, FldsBC::PERIODIC }
+        { FldsBC::MATCH, FldsBC::MATCH }
       };
       assert_equal<FldsBC>(
         params_mink_1d.get<boundaries_t<FldsBC>>("grid.boundaries.fields")[0].first,
@@ -283,6 +283,14 @@ auto main(int argc, char* argv[]) -> int {
         params_mink_1d.get<boundaries_t<FldsBC>>("grid.boundaries.fields").size(),
         fbc.size(),
         "grid.boundaries.fields.size()");
+      assert_equal(
+        params_mink_1d.get<boundaries_t<real_t>>("grid.boundaries.match.ds")[0].first,
+        (real_t)0.025,
+        "grid.boundaries.match.ds[0].first");
+      assert_equal(
+        params_mink_1d.get<boundaries_t<real_t>>("grid.boundaries.match.ds")[0].second,
+        (real_t)0.1,
+        "grid.boundaries.match.ds[0].first");
 
       const auto species = params_mink_1d.get<std::vector<ParticleSpecies>>(
         "particles.species");
@@ -383,7 +391,7 @@ auto main(int argc, char* argv[]) -> int {
 
       // match coeffs
       assert_equal<real_t>(
-        params_sph_2d.get<real_t>("grid.boundaries.match.ds"),
+        params_sph_2d.get<boundaries_t<real_t>>("grid.boundaries.match.ds")[0].second,
         (real_t)(defaults::bc::match::ds_frac * 19.0),
         "grid.boundaries.match.ds");
 
@@ -539,7 +547,7 @@ auto main(int argc, char* argv[]) -> int {
 
       // match coeffs
       assert_equal<real_t>(
-        params_qks_2d.get<real_t>("grid.boundaries.match.ds"),
+        params_qks_2d.get<boundaries_t<real_t>>("grid.boundaries.match.ds")[0].second,
         (real_t)(defaults::bc::match::ds_frac * (100.0 - 0.8)),
         "grid.boundaries.match.ds");
 

--- a/src/global/arch/kokkos_aliases.cpp
+++ b/src/global/arch/kokkos_aliases.cpp
@@ -9,73 +9,75 @@ auto CreateParticleRangePolicy(npart_t p1, npart_t p2) -> range_t<Dim::_1D> {
 }
 
 template <>
-auto CreateRangePolicy<Dim::_1D>(
-  const tuple_t<ncells_t, Dim::_1D>& i1,
-  const tuple_t<ncells_t, Dim::_1D>& i2) -> range_t<Dim::_1D> {
+auto CreateRangePolicy<Dim::_1D>(const tuple_t<ncells_t, Dim::_1D>& i1,
+                                 const tuple_t<ncells_t, Dim::_1D>& i2)
+  -> range_t<Dim::_1D> {
   index_t i1min = i1[0];
   index_t i1max = i2[0];
-  return Kokkos::RangePolicy<AccelExeSpace>(i1min, i1max);
+  return Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(i1min, i1max);
 }
 
 template <>
-auto CreateRangePolicy<Dim::_2D>(
-  const tuple_t<ncells_t, Dim::_2D>& i1,
-  const tuple_t<ncells_t, Dim::_2D>& i2) -> range_t<Dim::_2D> {
+auto CreateRangePolicy<Dim::_2D>(const tuple_t<ncells_t, Dim::_2D>& i1,
+                                 const tuple_t<ncells_t, Dim::_2D>& i2)
+  -> range_t<Dim::_2D> {
   index_t i1min = i1[0];
   index_t i1max = i2[0];
   index_t i2min = i1[1];
   index_t i2max = i2[1];
-  return Kokkos::MDRangePolicy<Kokkos::Rank<2>, AccelExeSpace>({ i1min, i2min },
-                                                               { i1max, i2max });
+  return Kokkos::MDRangePolicy<Kokkos::Rank<2>, Kokkos::DefaultExecutionSpace>(
+    { i1min, i2min },
+    { i1max, i2max });
 }
 
 template <>
-auto CreateRangePolicy<Dim::_3D>(
-  const tuple_t<ncells_t, Dim::_3D>& i1,
-  const tuple_t<ncells_t, Dim::_3D>& i2) -> range_t<Dim::_3D> {
+auto CreateRangePolicy<Dim::_3D>(const tuple_t<ncells_t, Dim::_3D>& i1,
+                                 const tuple_t<ncells_t, Dim::_3D>& i2)
+  -> range_t<Dim::_3D> {
   index_t i1min = i1[0];
   index_t i1max = i2[0];
   index_t i2min = i1[1];
   index_t i2max = i2[1];
   index_t i3min = i1[2];
   index_t i3max = i2[2];
-  return Kokkos::MDRangePolicy<Kokkos::Rank<3>, AccelExeSpace>(
+  return Kokkos::MDRangePolicy<Kokkos::Rank<3>, Kokkos::DefaultExecutionSpace>(
     { i1min, i2min, i3min },
     { i1max, i2max, i3max });
 }
 
 template <>
-auto CreateRangePolicyOnHost<Dim::_1D>(
-  const tuple_t<ncells_t, Dim::_1D>& i1,
-  const tuple_t<ncells_t, Dim::_1D>& i2) -> range_h_t<Dim::_1D> {
+auto CreateRangePolicyOnHost<Dim::_1D>(const tuple_t<ncells_t, Dim::_1D>& i1,
+                                       const tuple_t<ncells_t, Dim::_1D>& i2)
+  -> range_h_t<Dim::_1D> {
   index_t i1min = i1[0];
   index_t i1max = i2[0];
-  return Kokkos::RangePolicy<HostExeSpace>(i1min, i1max);
+  return Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(i1min, i1max);
 }
 
 template <>
-auto CreateRangePolicyOnHost<Dim::_2D>(
-  const tuple_t<ncells_t, Dim::_2D>& i1,
-  const tuple_t<ncells_t, Dim::_2D>& i2) -> range_h_t<Dim::_2D> {
+auto CreateRangePolicyOnHost<Dim::_2D>(const tuple_t<ncells_t, Dim::_2D>& i1,
+                                       const tuple_t<ncells_t, Dim::_2D>& i2)
+  -> range_h_t<Dim::_2D> {
   index_t i1min = i1[0];
   index_t i1max = i2[0];
   index_t i2min = i1[1];
   index_t i2max = i2[1];
-  return Kokkos::MDRangePolicy<Kokkos::Rank<2>, HostExeSpace>({ i1min, i2min },
-                                                              { i1max, i2max });
+  return Kokkos::MDRangePolicy<Kokkos::Rank<2>, Kokkos::DefaultHostExecutionSpace>(
+    { i1min, i2min },
+    { i1max, i2max });
 }
 
 template <>
-auto CreateRangePolicyOnHost<Dim::_3D>(
-  const tuple_t<ncells_t, Dim::_3D>& i1,
-  const tuple_t<ncells_t, Dim::_3D>& i2) -> range_h_t<Dim::_3D> {
+auto CreateRangePolicyOnHost<Dim::_3D>(const tuple_t<ncells_t, Dim::_3D>& i1,
+                                       const tuple_t<ncells_t, Dim::_3D>& i2)
+  -> range_h_t<Dim::_3D> {
   index_t i1min = i1[0];
   index_t i1max = i2[0];
   index_t i2min = i1[1];
   index_t i2max = i2[1];
   index_t i3min = i1[2];
   index_t i3max = i2[2];
-  return Kokkos::MDRangePolicy<Kokkos::Rank<3>, HostExeSpace>(
+  return Kokkos::MDRangePolicy<Kokkos::Rank<3>, Kokkos::DefaultHostExecutionSpace>(
     { i1min, i2min, i3min },
     { i1max, i2max, i3max });
 }

--- a/src/global/arch/kokkos_aliases.h
+++ b/src/global/arch/kokkos_aliases.h
@@ -34,7 +34,7 @@
 namespace math = Kokkos;
 
 template <typename T>
-using array_t = Kokkos::View<T, AccelMemSpace>;
+using array_t = Kokkos::View<T>;
 
 // Array mirror alias of arbitrary type
 template <typename T>
@@ -174,17 +174,17 @@ namespace kokkos_aliases_hidden {
 
   template <>
   struct range_impl<Dim::_1D> {
-    using type = Kokkos::RangePolicy<AccelExeSpace>;
+    using type = Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>;
   };
 
   template <>
   struct range_impl<Dim::_2D> {
-    using type = Kokkos::MDRangePolicy<Kokkos::Rank<2>, AccelExeSpace>;
+    using type = Kokkos::MDRangePolicy<Kokkos::Rank<2>, Kokkos::DefaultExecutionSpace>;
   };
 
   template <>
   struct range_impl<Dim::_3D> {
-    using type = Kokkos::MDRangePolicy<Kokkos::Rank<3>, AccelExeSpace>;
+    using type = Kokkos::MDRangePolicy<Kokkos::Rank<3>, Kokkos::DefaultExecutionSpace>;
   };
 } // namespace kokkos_aliases_hidden
 
@@ -201,17 +201,17 @@ namespace kokkos_aliases_hidden {
 
   template <>
   struct range_h_impl<Dim::_1D> {
-    using type = Kokkos::RangePolicy<HostExeSpace>;
+    using type = Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>;
   };
 
   template <>
   struct range_h_impl<Dim::_2D> {
-    using type = Kokkos::MDRangePolicy<Kokkos::Rank<2>, HostExeSpace>;
+    using type = Kokkos::MDRangePolicy<Kokkos::Rank<2>, Kokkos::DefaultHostExecutionSpace>;
   };
 
   template <>
   struct range_h_impl<Dim::_3D> {
-    using type = Kokkos::MDRangePolicy<Kokkos::Rank<3>, HostExeSpace>;
+    using type = Kokkos::MDRangePolicy<Kokkos::Rank<3>, Kokkos::DefaultHostExecutionSpace>;
   };
 
 } // namespace kokkos_aliases_hidden
@@ -234,8 +234,8 @@ auto CreateParticleRangePolicy(npart_t, npart_t) -> range_t<Dim::_1D>;
  * @returns Kokkos::RangePolicy or Kokkos::MDRangePolicy in the accelerator execution space.
  */
 template <Dimension D>
-auto CreateRangePolicy(const tuple_t<ncells_t, D>&,
-                       const tuple_t<ncells_t, D>&) -> range_t<D>;
+auto CreateRangePolicy(const tuple_t<ncells_t, D>&, const tuple_t<ncells_t, D>&)
+  -> range_t<D>;
 
 /**
  * @brief Function template for generating ND Kokkos range policy on the host.
@@ -249,8 +249,8 @@ auto CreateRangePolicyOnHost(const tuple_t<ncells_t, D>&,
                              const tuple_t<ncells_t, D>&) -> range_h_t<D>;
 
 // Random number pool/generator type alias
-using random_number_pool_t = Kokkos::Random_XorShift1024_Pool<AccelExeSpace>;
-using random_generator_t   = typename random_number_pool_t::generator_type;
+using random_number_pool_t = Kokkos::Random_XorShift1024_Pool<Kokkos::DefaultExecutionSpace>;
+using random_generator_t = typename random_number_pool_t::generator_type;
 
 // Random number generator functions
 template <typename T>

--- a/src/global/arch/traits.h
+++ b/src/global/arch/traits.h
@@ -104,6 +104,15 @@ namespace traits {
     using match_fields_t = decltype(&T::MatchFields);
 
     template <typename T>
+    using match_fields_in_x1_t = decltype(&T::MatchFieldsInX1);
+
+    template <typename T>
+    using match_fields_in_x2_t = decltype(&T::MatchFieldsInX2);
+
+    template <typename T>
+    using match_fields_in_x3_t = decltype(&T::MatchFieldsInX3);
+
+    template <typename T>
     using match_fields_const_t = decltype(&T::MatchFieldsConst);
 
     template <typename T>

--- a/src/kernels/injectors.hpp
+++ b/src/kernels/injectors.hpp
@@ -49,7 +49,7 @@ namespace kernel {
 
     npart_t                offset1, offset2;
     const M                metric;
-    const array_t<real_t*> ni;
+    const array_t<real_t*> i_min, i_max;
     const ED               energy_dist;
     const real_t           inv_V0;
     random_number_pool_t   random_pool;
@@ -61,7 +61,8 @@ namespace kernel {
                            npart_t                          offset1,
                            npart_t                          offset2,
                            const M&                         metric,
-                           const array_t<real_t*>&          ni,
+                           const array_t<real_t*>&          i_min,
+                           const array_t<real_t*>&          i_max,
                            const ED&                        energy_dist,
                            real_t                           inv_V0,
                            random_number_pool_t&            random_pool)
@@ -94,7 +95,8 @@ namespace kernel {
       , offset1 { offset1 }
       , offset2 { offset2 }
       , metric { metric }
-      , ni { ni }
+      , i_min { i_min }
+      , i_max { i_max }
       , energy_dist { energy_dist }
       , inv_V0 { inv_V0 }
       , random_pool { random_pool } {}
@@ -104,12 +106,12 @@ namespace kernel {
       vec_t<Dim::_3D> v1 { ZERO }, v2 { ZERO };
       { // generate a random coordinate
         auto rand_gen = random_pool.get_state();
-        x_Cd[0]       = Random<real_t>(rand_gen) * ni(0);
+        x_Cd[0] = i_min(0) + Random<real_t>(rand_gen) * (i_max(0) - i_min(0));
         if constexpr (M::Dim == Dim::_2D or M::Dim == Dim::_3D) {
-          x_Cd[1] = Random<real_t>(rand_gen) * ni(1);
+          x_Cd[1] = i_min(1) + Random<real_t>(rand_gen) * (i_max(1) - i_min(1));
         }
         if constexpr (M::Dim == Dim::_3D) {
-          x_Cd[2] = Random<real_t>(rand_gen) * ni(2);
+          x_Cd[2] = i_min(2) + Random<real_t>(rand_gen) * (i_max(2) - i_min(2));
         }
         random_pool.free_state(rand_gen);
       }

--- a/src/kernels/tests/prtls_to_phys.cpp
+++ b/src/kernels/tests/prtls_to_phys.cpp
@@ -132,7 +132,7 @@ void testPrtl2PhysSR(const std::vector<std::size_t>&      res,
 
   extent = {
     ext[0],
-    {ZERO, constant::PI}
+    { ZERO, constant::PI }
   };
 
   const M metric { res, extent, params };
@@ -177,28 +177,29 @@ void testPrtl2PhysSR(const std::vector<std::size_t>&      res,
   array_t<real_t*>  buff_ux3 { "buff_ux3", nprtl / stride };
   array_t<real_t*>  buff_wei { "buff_wei", nprtl / stride };
 
-  Kokkos::parallel_for("Init",
-                       Kokkos::RangePolicy<AccelExeSpace>(0, nprtl / stride),
-                       kernel::PrtlToPhys_kernel<SimEngine::SRPIC, M>(stride,
-                                                                      buff_x1,
-                                                                      buff_x2,
-                                                                      buff_x3,
-                                                                      buff_ux1,
-                                                                      buff_ux2,
-                                                                      buff_ux3,
-                                                                      buff_wei,
-                                                                      i1,
-                                                                      i2,
-                                                                      i3,
-                                                                      dx1,
-                                                                      dx2,
-                                                                      dx3,
-                                                                      ux1,
-                                                                      ux2,
-                                                                      ux3,
-                                                                      phi,
-                                                                      weight,
-                                                                      metric));
+  Kokkos::parallel_for(
+    "Init",
+    Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, nprtl / stride),
+    kernel::PrtlToPhys_kernel<SimEngine::SRPIC, M>(stride,
+                                                   buff_x1,
+                                                   buff_x2,
+                                                   buff_x3,
+                                                   buff_ux1,
+                                                   buff_ux2,
+                                                   buff_ux3,
+                                                   buff_wei,
+                                                   i1,
+                                                   i2,
+                                                   i3,
+                                                   dx1,
+                                                   dx2,
+                                                   dx3,
+                                                   ux1,
+                                                   ux2,
+                                                   ux3,
+                                                   phi,
+                                                   weight,
+                                                   metric));
   Kokkos::parallel_for("Check",
                        nprtl / stride,
                        Checker<M>(metric,


### PR DESCRIPTION
Changes:
- `match.ds` can now be a vector (optional)
- `box` can be passed to `InjectUniform` to specify the injection region

To-Do:
- [ ] `KeepConstInjector` (based on `InjectUniform`) (for reconnection)
- [ ] Moving injector (for shock)