### PR TITLE
Adding driving by external fields

### DIFF
--- a/src/global/arch/traits.h
+++ b/src/global/arch/traits.h
@@ -53,6 +53,15 @@ namespace traits {
   // for fieldsetter
   // special ::ex1, ::ex2, ::ex3, ::bx1, ::bx2, ::bx3, ::dx1, ::dx2, ::dx3
   template <typename T>
+  using fx1_t = decltype(&T::fx1);
+
+  template <typename T>
+  using fx2_t = decltype(&T::fx2);
+
+  template <typename T>
+  using fx3_t = decltype(&T::fx3);
+  
+  template <typename T>
   using ex1_t = decltype(&T::ex1);
 
   template <typename T>


### PR DESCRIPTION
This PR adds support for prescribing an external electric field in the particle pusher via the ext_force infrastructure. The implementation follows Arno Vanthieghem’s previous approach. Future separation as a standalone function (instead of a combination with ext_force) is possible.

Key Features:
External E-field driver added to the ext_force mechanism.
Time- and space-dependent field definitions are supported.
Enables controlled field-driving experiments (e.g., for wave excitation or forced dynamics).

Notes:
Currently, the No_Force logic is not very elegant in the pusher, it needs work.
This addition affects only the external force logic applied during the particle push.