### PR TITLE
Archetypes simplified

### DIFF
--- a/compile_pgens.sh
+++ b/compile_pgens.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+pgens=("magnetosphere" "reconnection" "turbulence" "shock" "streaming" "accretion" "wald")
+flags=("OFFLINE=ON")
+
+for pgen in "${pgens[@]}"; do
+  echo "Compiling pgen: $pgen"
+  flags_d="-D pgen=${pgen} "
+  for flag in "${flags[@]}"; do
+    flags_d+="-D ${flag}"
+  done
+
+  (
+    cmake -B "builds/build-${pgen}" $flags_d &&
+      cmake --build "builds/build-${pgen}" -j &&
+      mkdir -p "temp/${pgen}" &&
+      cp "builds/build-${pgen}/src/entity.xc" "temp/${pgen}/" &&
+      cp "pgens/${pgen}/"*.toml "temp/${pgen}/"
+  ) || {
+    echo "Failed to compile pgen: $pgen"
+    exit 1
+  }
+done
+
+for pgen in "${pgens[@]}"; do
+  cd "temp/${pgen}" || {
+    echo "no temp directory for $pgen"
+    exit 1
+  }
+  tomls=$(find . -type f -name "*.toml")
+  for toml in "${tomls[@]}"; do
+    (
+      echo "Running pgen: $pgen with config $toml" &&
+        ./entity.xc -input "$toml" &&
+        cd ../../
+    ) || {
+      echo "Failed to run $pgen with config $toml"
+      exit 1
+    }
+  done
+done

--- a/pgens/accretion/accretion.toml
+++ b/pgens/accretion/accretion.toml
@@ -67,7 +67,7 @@
   m_eps        = 1.0
 
 [output]
-  format = "hdf5"
+  format = "BPFile"
 
   [output.fields]
     interval_time = 1.0

--- a/pgens/accretion/pgen.hpp
+++ b/pgens/accretion/pgen.hpp
@@ -43,8 +43,7 @@ namespace user {
                      TWO * metric.spin() * g_00);
     }
 
-    Inline auto bx1(const coord_t<D>& x_Ph) const
-      -> real_t { // at ( i , j + HALF )
+    Inline auto bx1(const coord_t<D>& x_Ph) const -> real_t { // at ( i , j + HALF )
       coord_t<D> xi { ZERO }, x0m { ZERO }, x0p { ZERO };
       metric.template convert<Crd::Ph, Crd::Cd>(x_Ph, xi);
 
@@ -62,8 +61,7 @@ namespace user {
       }
     }
 
-    Inline auto bx2(const coord_t<D>& x_Ph) const
-      -> real_t { // at ( i + HALF , j )
+    Inline auto bx2(const coord_t<D>& x_Ph) const -> real_t { // at ( i + HALF , j )
       coord_t<D> xi { ZERO }, x0m { ZERO }, x0p { ZERO };
       metric.template convert<Crd::Ph, Crd::Cd>(x_Ph, xi);
 
@@ -242,16 +240,14 @@ namespace user {
                                                         params,
                                                         &local_domain);
 
-      const auto injector =
-        arch::NonUniformInjector<S, M, arch::Maxwellian, PointDistribution>(
-          energy_dist,
-          spatial_dist,
-          { 1, 2 });
-      arch::InjectNonUniform<S, M, decltype(injector)>(params,
-                                                       local_domain,
-                                                       injector,
-                                                       1.0,
-                                                       true);
+      arch::InjectNonUniform<S, M, decltype(energy_dist), decltype(energy_dist), decltype(spatial_dist)>(
+        params,
+        local_domain,
+        { 1, 2 },
+        { energy_dist, energy_dist },
+        spatial_dist,
+        ONE,
+        true);
     }
 
     void CustomPostStep(std::size_t, long double time, Domain<S, M>& local_domain) {
@@ -264,17 +260,14 @@ namespace user {
                                                         multiplicity * nGJ,
                                                         params,
                                                         &local_domain);
-
-      const auto injector =
-        arch::NonUniformInjector<S, M, arch::Maxwellian, PointDistribution>(
-          energy_dist,
-          spatial_dist,
-          { 1, 2 });
-      arch::InjectNonUniform<S, M, decltype(injector)>(params,
-                                                       local_domain,
-                                                       injector,
-                                                       1.0,
-                                                       true);
+      arch::InjectNonUniform<S, M, decltype(energy_dist), decltype(energy_dist), decltype(spatial_dist)>(
+        params,
+        local_domain,
+        { 1, 2 },
+        { energy_dist, energy_dist },
+        spatial_dist,
+        ONE,
+        true);
     }
   };
 

--- a/pgens/magnetosphere/magnetosphere.toml
+++ b/pgens/magnetosphere/magnetosphere.toml
@@ -63,7 +63,7 @@
   period         = 60.0
 
 [output]
-  format = "hdf5"
+  format = "BPFile"
 
   [output.fields]
     interval_time = 0.1
@@ -74,6 +74,3 @@
 
   [output.spectra]
     enable = false
-
-[diagnostics]
-  interval = 50

--- a/pgens/reconnection/pgen.hpp
+++ b/pgens/reconnection/pgen.hpp
@@ -4,7 +4,6 @@
 #include "enums.h"
 #include "global.h"
 
-#include "arch/directions.h"
 #include "arch/kokkos_aliases.h"
 #include "arch/traits.h"
 #include "utils/numeric.h"
@@ -140,15 +139,6 @@ namespace user {
 
   // constant particle density for particle boundaries
   template <SimEngine::type S, class M>
-  struct ConstDens {
-    Inline auto operator()(const coord_t<M::Dim>& x_Ph) const -> real_t {
-      return ONE;
-    }
-  };
-  template <SimEngine::type S, class M>
-  using spatial_dist_t = arch::Replenish<S, M, ConstDens<S, M>>;
-
-  template <SimEngine::type S, class M>
   struct PGen : public arch::ProblemGenerator<S, M> {
     // compatibility traits for the problem generator
     static constexpr auto engines { traits::compatible_with<SimEngine::SRPIC>::value };
@@ -224,21 +214,18 @@ namespace user {
       auto       edist_cs = arch::Maxwellian<S, M>(local_domain.mesh.metric,
                                              local_domain.random_pool,
                                              cs_temperature,
-                                             cs_drift_u,
-                                             in::x3,
-                                             false);
+                                                   { ZERO, ZERO, cs_drift_u });
       const auto sdist_cs = CurrentLayer<S, M>(local_domain.mesh.metric,
                                                cs_width,
                                                cs_x,
                                                cs_y);
-      const auto inj_cs = arch::NonUniformInjector<S, M, arch::Maxwellian, CurrentLayer>(
-        edist_cs,
+      arch::InjectNonUniform<S, M, decltype(edist_cs), decltype(edist_cs), decltype(sdist_cs)>(
+        params,
+        local_domain,
+        { 1, 2 },
+        { edist_cs, edist_cs },
         sdist_cs,
-        { 1, 2 });
-      arch::InjectNonUniform<S, M, decltype(inj_cs)>(params,
-                                                     local_domain,
-                                                     inj_cs,
-                                                     cs_overdensity);
+        cs_overdensity);
     }
 
     void CustomPostStep(timestep_t, simtime_t time, Domain<S, M>& domain) {
@@ -303,28 +290,26 @@ namespace user {
         Kokkos::Experimental::contribute(domain.fields.buff, scatter_buff);
       }
 
-      const auto injector_up = arch::KeepConstantInjector<S, M, arch::Maxwellian>(
-        energy_dist,
-        { 1, 2 },
+      const auto replenish_sdist = arch::ReplenishUniform<S, M, 3>(
+        domain.mesh.metric,
+        domain.fields.buff,
         0u,
-        probe_box_up);
-      const auto injector_down = arch::KeepConstantInjector<S, M, arch::Maxwellian>(
-        energy_dist,
-        { 1, 2 },
-        0u,
-        probe_box_down);
-
-      arch::InjectUniform<S, M, decltype(injector_up)>(
+        ONE);
+      arch::InjectNonUniform<S, M, decltype(energy_dist), decltype(energy_dist), decltype(replenish_sdist)>(
         params,
         domain,
-        injector_up,
+        { 1, 2 },
+        { energy_dist, energy_dist },
+        replenish_sdist,
         ONE,
         params.template get<bool>("particles.use_weights"),
         inj_box_up);
-      arch::InjectUniform<S, M, decltype(injector_down)>(
+      arch::InjectNonUniform<S, M, decltype(energy_dist), decltype(energy_dist), decltype(replenish_sdist)>(
         params,
         domain,
-        injector_down,
+        { 1, 2 },
+        { energy_dist, energy_dist },
+        replenish_sdist,
         ONE,
         params.template get<bool>("particles.use_weights"),
         inj_box_down);

--- a/pgens/reconnection/pgen.hpp
+++ b/pgens/reconnection/pgen.hpp
@@ -245,15 +245,10 @@ namespace user {
       const auto dx = domain.mesh.metric.template sqrt_h_<1, 1>({});
 
       boundaries_t<real_t> inj_box_up, inj_box_down;
-      boundaries_t<real_t> probe_box_up, probe_box_down;
       inj_box_up.push_back(Range::All);
       inj_box_down.push_back(Range::All);
-      probe_box_up.push_back(Range::All);
-      probe_box_down.push_back(Range::All);
       inj_box_up.push_back({ ymax - inj_ypad - 10 * dx, ymax - inj_ypad });
       inj_box_down.push_back({ ymin + inj_ypad, ymin + inj_ypad + 10 * dx });
-      probe_box_up.push_back({ ymax - inj_ypad - 10 * dx, ymax - inj_ypad });
-      probe_box_down.push_back({ ymin + inj_ypad, ymin + inj_ypad + 10 * dx });
 
       if constexpr (M::Dim == Dim::_3D) {
         inj_box_up.push_back(Range::All);

--- a/pgens/shock/pgen.hpp
+++ b/pgens/shock/pgen.hpp
@@ -8,9 +8,7 @@
 #include "utils/error.h"
 #include "utils/numeric.h"
 
-#include "archetypes/energy_dist.h"
 #include "archetypes/field_setter.h"
-#include "archetypes/particle_injector.h"
 #include "archetypes/problem_generator.h"
 #include "archetypes/utils.h"
 #include "framework/domain/metadomain.h"
@@ -179,7 +177,7 @@ namespace user {
       const auto drifts       = std::make_pair(
         std::vector<real_t> { -drift_ux, ZERO, ZERO },
         std::vector<real_t> { -drift_ux, ZERO, ZERO });
-      
+
       // inject particles
       arch::InjectUniformMaxwellians<S, M>(params,
                                            domain,

--- a/pgens/shock/shock.toml
+++ b/pgens/shock/shock.toml
@@ -4,7 +4,7 @@
   runtime = 50.0
 
   [simulation.domain]
-    decomposition = [1,-1]
+    decomposition = [1, -1]
 
 [grid]
   resolution = [4096, 128]
@@ -14,10 +14,10 @@
     metric = "minkowski"
 
   [grid.boundaries]
-    fields = [["CONDUCTOR", "MATCH"], ["PERIODIC"]]
+    fields    = [["CONDUCTOR", "MATCH"], ["PERIODIC"]]
     particles = [["REFLECT", "ABSORB"], ["PERIODIC"]]
 
-    
+
 [scales]
   larmor0    = 0.057735
   skindepth0 = 0.01
@@ -44,27 +44,27 @@
     maxnpart = 8e7
 
 [setup]
-  drift_ux    = 0.15            # speed towards the wall [c]
-  temperature = 0.001683        # temperature of maxwell distribution [kB T / (m_i c^2)]
-  temperature_ratio = 1.0       # temperature ratio of electrons to protons
-  Bmag = 1.0                    # magnetic field strength as fraction of magnetisation
-  Btheta = 63.0                 # magnetic field angle in the plane
-  Bphi = 0.0                    # magnetic field angle out of plane
-  filling_fraction = 0.1        # fraction of the shock piston filled with plasma
-  injector_velocity = 0.2       # speed of injector [c]
-  injection_start = 0.0         # start time of moving injector
-  injection_frequency = 100     # inject particles every 100 timesteps
+  drift_ux            = 0.15     # speed towards the wall [c]
+  temperature         = 0.001683 # temperature of maxwell distribution [kB T / (m_i c^2)]
+  temperature_ratio   = 1.0      # temperature ratio of electrons to protons
+  Bmag                = 1.0      # magnetic field strength as fraction of magnetisation
+  Btheta              = 63.0     # magnetic field angle in the plane
+  Bphi                = 0.0      # magnetic field angle out of plane
+  filling_fraction    = 0.1      # fraction of the shock piston filled with plasma
+  injector_velocity   = 0.2      # speed of injector [c]
+  injection_start     = 0.0      # start time of moving injector
+  injection_frequency = 100      # inject particles every 100 timesteps
 
 [output]
   interval_time = 0.1
-  format        = "hdf5"
-  
+  format        = "BPFile"
+
   [output.fields]
     quantities = ["N_1", "N_2", "B", "E"]
 
   [output.particles]
     enable = true
-    stride = 10 
+    stride = 10
 
   [output.spectra]
     enable = false

--- a/pgens/turbulence/turbulence.toml
+++ b/pgens/turbulence/turbulence.toml
@@ -42,12 +42,12 @@
 [setup]
   temperature = 1e0
   dB          = 1.0
-  omega_0 = 0.0156
-  gamma_0 = 0.0078
-     
+  omega_0     = 0.0156
+  gamma_0     = 0.0078
+
 
 [output]
-  format        = "hdf5"
+  format        = "BPFile"
   interval_time = 12.0
 
   [output.fields]

--- a/pgens/wald/wald.toml
+++ b/pgens/wald/wald.toml
@@ -41,7 +41,7 @@
   init_field = "wald" # or "vertical"
 
 [output]
-  format = "hdf5"
+  format = "BPFile"
 
   [output.fields]
     interval_time = 1.0

--- a/src/archetypes/energy_dist.h
+++ b/src/archetypes/energy_dist.h
@@ -48,9 +48,7 @@ namespace arch {
   struct Cold : public EnergyDistribution<S, M> {
     Cold(const M& metric) : EnergyDistribution<S, M> { metric } {}
 
-    Inline void operator()(const coord_t<M::Dim>&,
-                           vec_t<Dim::_3D>& v,
-                           spidx_t = 0) const {
+    Inline void operator()(const coord_t<M::Dim>&, vec_t<Dim::_3D>& v) const {
 
       v[0] = ZERO;
       v[1] = ZERO;
@@ -73,9 +71,7 @@ namespace arch {
       , pl_ind { pl_ind }
       , pool { pool } {}
 
-    Inline void operator()(const coord_t<M::Dim>&,
-                           vec_t<Dim::_3D>& v,
-                           spidx_t = 0) const {
+    Inline void operator()(const coord_t<M::Dim>&, vec_t<Dim::_3D>& v) const {
       auto rand_gen = pool.get_state();
       auto rand_X1  = Random<real_t>(rand_gen);
       auto rand_gam = ONE;
@@ -254,9 +250,7 @@ namespace arch {
       }
     }
 
-    Inline void operator()(const coord_t<M::Dim>& x_Code,
-                           vec_t<Dim::_3D>&       v,
-                           spidx_t = 0) const {
+    Inline void operator()(const coord_t<M::Dim>& x_Code, vec_t<Dim::_3D>& v) const {
       if (cmp::AlmostZero(temperature)) {
         v[0] = ZERO;
         v[1] = ZERO;

--- a/src/archetypes/particle_injector.h
+++ b/src/archetypes/particle_injector.h
@@ -2,9 +2,9 @@
  * @file archetypes/particle_injector.h
  * @brief Particle injector routines and classes
  * @implements
- *   - arch::UniformInjector<>
- *   - arch::NonUniformInjector<>
- *   - arch::AtmosphereInjector<>
+ *   - arch::DeduceRegion<> -> tuple<bool, array_t<real_t*>, array_t<real_t*>>
+ *   - arch::ComputeNumInject<> -> tuple<bool, npart_t, array_t<real_t*>, array_t<real_t*>>
+ *   - arch::AtmosphereDensityProfile<>
  *   - arch::InjectUniform<> -> void
  *   - arch::InjectGlobally<> -> void
  *   - arch::InjectNonUniform<> -> void
@@ -22,13 +22,10 @@
 #include "utils/error.h"
 #include "utils/numeric.h"
 
-#include "archetypes/energy_dist.h"
-#include "archetypes/spatial_dist.h"
 #include "framework/domain/domain.h"
 #include "framework/domain/metadomain.h"
 
 #include "kernels/injectors.hpp"
-#include "kernels/utils.hpp"
 
 #include <Kokkos_Core.hpp>
 
@@ -44,515 +41,173 @@
 namespace arch {
   using namespace ntt;
 
+  /**
+   * @brief Deduces the region of injection in computational coordinates
+   * @param domain Domain object
+   * @param box Region to inject the particles in global coords
+   * @tparam S Simulation engine type
+   * @tparam M Metric type
+   * @return Tuple containing:
+   *   - bool: whether the region intersects with the local domain
+   *   - array_t<real_t*>: minimum coordinates of the region in computational coords
+   *   - array_t<real_t*>: maximum coordinates of the region in computational coords
+   */
   template <SimEngine::type S, class M>
-  struct BaseInjector {
-    virtual auto DeduceRegion(const Domain<S, M>&         domain,
-                              const boundaries_t<real_t>& box) const
-      -> std::tuple<bool, array_t<real_t*>, array_t<real_t*>> {
-      if (not domain.mesh.Intersects(box)) {
-        return { false, array_t<real_t*> {}, array_t<real_t*> {} };
-      }
-      coord_t<M::Dim> xCorner_min_Ph { ZERO };
-      coord_t<M::Dim> xCorner_max_Ph { ZERO };
-      coord_t<M::Dim> xCorner_min_Cd { ZERO };
-      coord_t<M::Dim> xCorner_max_Cd { ZERO };
+  auto DeduceRegion(const Domain<S, M>& domain, const boundaries_t<real_t>& box)
+    -> std::tuple<bool, array_t<real_t*>, array_t<real_t*>> {
+    if (not domain.mesh.Intersects(box)) {
+      return { false, array_t<real_t*> {}, array_t<real_t*> {} };
+    }
+    coord_t<M::Dim> xCorner_min_Ph { ZERO };
+    coord_t<M::Dim> xCorner_max_Ph { ZERO };
+    coord_t<M::Dim> xCorner_min_Cd { ZERO };
+    coord_t<M::Dim> xCorner_max_Cd { ZERO };
 
-      for (auto d { 0u }; d < M::Dim; ++d) {
-        const auto local_xi_min = domain.mesh.extent(static_cast<in>(d)).first;
-        const auto local_xi_max = domain.mesh.extent(static_cast<in>(d)).second;
-        const auto extent_min   = std::min(std::max(local_xi_min, box[d].first),
-                                         local_xi_max);
-        const auto extent_max = std::max(std::min(local_xi_max, box[d].second),
-                                         local_xi_min);
-        xCorner_min_Ph[d]     = extent_min;
-        xCorner_max_Ph[d]     = extent_max;
-      }
-      domain.mesh.metric.template convert<Crd::Ph, Crd::Cd>(xCorner_min_Ph,
-                                                            xCorner_min_Cd);
-      domain.mesh.metric.template convert<Crd::Ph, Crd::Cd>(xCorner_max_Ph,
-                                                            xCorner_max_Cd);
+    for (auto d { 0u }; d < M::Dim; ++d) {
+      const auto local_xi_min = domain.mesh.extent(static_cast<in>(d)).first;
+      const auto local_xi_max = domain.mesh.extent(static_cast<in>(d)).second;
+      const auto extent_min   = std::min(std::max(local_xi_min, box[d].first),
+                                       local_xi_max);
+      const auto extent_max   = std::max(std::min(local_xi_max, box[d].second),
+                                       local_xi_min);
+      xCorner_min_Ph[d]       = extent_min;
+      xCorner_max_Ph[d]       = extent_max;
+    }
+    domain.mesh.metric.template convert<Crd::Ph, Crd::Cd>(xCorner_min_Ph,
+                                                          xCorner_min_Cd);
+    domain.mesh.metric.template convert<Crd::Ph, Crd::Cd>(xCorner_max_Ph,
+                                                          xCorner_max_Cd);
 
-      array_t<real_t*> xi_min { "xi_min", M::Dim }, xi_max { "xi_max", M::Dim };
+    array_t<real_t*> xi_min { "xi_min", M::Dim }, xi_max { "xi_max", M::Dim };
 
-      auto xi_min_h = Kokkos::create_mirror_view(xi_min);
-      auto xi_max_h = Kokkos::create_mirror_view(xi_max);
-      for (auto d { 0u }; d < M::Dim; ++d) {
-        xi_min_h(d) = xCorner_min_Cd[d];
-        xi_max_h(d) = xCorner_max_Cd[d];
-      }
-      Kokkos::deep_copy(xi_min, xi_min_h);
-      Kokkos::deep_copy(xi_max, xi_max_h);
+    auto xi_min_h = Kokkos::create_mirror_view(xi_min);
+    auto xi_max_h = Kokkos::create_mirror_view(xi_max);
+    for (auto d { 0u }; d < M::Dim; ++d) {
+      xi_min_h(d) = xCorner_min_Cd[d];
+      xi_max_h(d) = xCorner_max_Cd[d];
+    }
+    Kokkos::deep_copy(xi_min, xi_min_h);
+    Kokkos::deep_copy(xi_max, xi_max_h);
 
-      return { true, xi_min, xi_max };
+    return { true, xi_min, xi_max };
+  }
+
+  /**
+   * @brief Computes the number of particles to inject in a given region
+   * @param params Simulation parameters
+   * @param domain Domain object
+   * @param number_density Number density (in units of n0)
+   * @param box Region to inject the particles in global coords
+   * @tparam S Simulation engine type
+   * @tparam M Metric type
+   * @return Tuple containing:
+   *   - bool: whether the region intersects with the local domain
+   *   - npart_t: number of particles to inject
+   *   - array_t<real_t*>: minimum coordinates of the region in computational coords
+   *   - array_t<real_t*>: maximum coordinates of the region in computational coords
+   */
+  template <SimEngine::type S, class M>
+  auto ComputeNumInject(const SimulationParams&     params,
+                        const Domain<S, M>&         domain,
+                        real_t                      number_density,
+                        const boundaries_t<real_t>& box)
+    -> std::tuple<bool, npart_t, array_t<real_t*>, array_t<real_t*>> {
+    const auto result = DeduceRegion(domain, box);
+    if (not std::get<0>(result)) {
+      return { false, (npart_t)0, array_t<real_t*> {}, array_t<real_t*> {} };
+    }
+    const auto xi_min   = std::get<1>(result);
+    const auto xi_max   = std::get<2>(result);
+    auto       xi_min_h = Kokkos::create_mirror_view(xi_min);
+    auto       xi_max_h = Kokkos::create_mirror_view(xi_max);
+    Kokkos::deep_copy(xi_min_h, xi_min);
+    Kokkos::deep_copy(xi_max_h, xi_max);
+
+    long double num_cells { 1.0 };
+    for (auto d { 0u }; d < M::Dim; ++d) {
+      num_cells *= static_cast<long double>(xi_max_h(d)) -
+                   static_cast<long double>(xi_min_h(d));
     }
 
-    virtual auto ComputeNumInject(const SimulationParams&     params,
-                                  const Domain<S, M>&         domain,
-                                  real_t                      number_density,
-                                  const boundaries_t<real_t>& box) const
-      -> std::tuple<bool, npart_t, array_t<real_t*>, array_t<real_t*>> {
-      const auto result = DeduceRegion(domain, box);
-      if (not std::get<0>(result)) {
-        return { false, (npart_t)0, array_t<real_t*> {}, array_t<real_t*> {} };
-      }
-      const auto xi_min   = std::get<1>(result);
-      const auto xi_max   = std::get<2>(result);
-      auto       xi_min_h = Kokkos::create_mirror_view(xi_min);
-      auto       xi_max_h = Kokkos::create_mirror_view(xi_max);
-      Kokkos::deep_copy(xi_min_h, xi_min);
-      Kokkos::deep_copy(xi_max_h, xi_max);
+    const auto ppc0       = params.template get<real_t>("particles.ppc0");
+    const auto nparticles = static_cast<npart_t>(
+      (long double)(ppc0 * number_density * 0.5) * num_cells);
 
-      long double num_cells { 1.0 };
-      for (auto d { 0u }; d < M::Dim; ++d) {
-        num_cells *= static_cast<long double>(xi_max_h(d)) -
-                     static_cast<long double>(xi_min_h(d));
-      }
+    return { true, nparticles, xi_min, xi_max };
+  }
 
-      const auto ppc0       = params.template get<real_t>("particles.ppc0");
-      const auto nparticles = static_cast<npart_t>(
-        (long double)(ppc0 * number_density * 0.5) * num_cells);
+  template <Dimension D, Coord::type C, bool P, in O>
+  struct AtmosphereDensityProfile {
+    const real_t nmax, height, xsurf, ds;
 
-      return { true, nparticles, xi_min, xi_max };
-    }
-  };
+    AtmosphereDensityProfile(real_t nmax, real_t height, real_t xsurf, real_t ds)
+      : nmax { nmax }
+      , height { height }
+      , xsurf { xsurf }
+      , ds { ds } {}
 
-  // template <SimEngine::type S, class M, template <SimEngine::type, class>
-  // class ED> struct UniformInjector : BaseInjector<S, M> {
-  //   using energy_dist_t = ED<S, M>;
-  //   static_assert(M::is_metric, "M must be a metric class");
-  //   static_assert(energy_dist_t::is_energy_dist,
-  //                 "E must be an energy distribution class");
-  //   static constexpr bool      is_uniform_injector { true };
-  //   static constexpr Dimension D { M::Dim };
-  //   static constexpr Coord     C { M::CoordType };
-  //
-  //   const energy_dist_t               energy_dist;
-  //   const std::pair<spidx_t, spidx_t> species;
-  //
-  //   UniformInjector(const energy_dist_t&               energy_dist,
-  //                   const std::pair<spidx_t, spidx_t>& species)
-  //     : energy_dist { energy_dist }
-  //     , species { species } {}
-  //
-  //   ~UniformInjector() = default;
-  // };
-
-  //   template <SimEngine::type S, class M, template <SimEngine::type, class> class ED>
-  //   struct KeepConstantInjector : UniformInjector<S, M, ED> {
-  //     using energy_dist_t = ED<S, M>;
-  //     using UniformInjector<S, M, ED>::D;
-  //     using UniformInjector<S, M, ED>::C;
-  //
-  //     const idx_t          density_buff_idx;
-  //     boundaries_t<real_t> probe_box;
-  //
-  //     KeepConstantInjector(const energy_dist_t&               energy_dist,
-  //                          const std::pair<spidx_t, spidx_t>& species,
-  //                          idx_t density_buff_idx, boundaries_t<real_t> box = {})
-  //       : UniformInjector<S, M, ED> { energy_dist, species }
-  //       , density_buff_idx { density_buff_idx } {
-  //       for (auto d { 0u }; d < M::Dim; ++d) {
-  //         if (d < box.size()) {
-  //           probe_box.push_back({ box[d].first, box[d].second });
-  //         } else {
-  //           probe_box.push_back(Range::All);
-  //         }
-  //       }
-  //     }
-  //
-  //     ~KeepConstantInjector() = default;
-  //
-  //     auto ComputeAvgDensity(const SimulationParams& params,
-  //                            const Domain<S, M>&     domain) const -> real_t {
-  //       const auto result       = this->DeduceRegion(domain, probe_box);
-  //       const auto should_probe = std::get<0>(result);
-  //       if (not should_probe) {
-  //         return ZERO;
-  //       }
-  //       const auto xi_min_arr = std::get<1>(result);
-  //       const auto xi_max_arr = std::get<2>(result);
-  //
-  //       tuple_t<ncells_t, M::Dim> i_min { 0 };
-  //       tuple_t<ncells_t, M::Dim> i_max { 0 };
-  //
-  //       auto xi_min_h = Kokkos::create_mirror_view(xi_min_arr);
-  //       auto xi_max_h = Kokkos::create_mirror_view(xi_max_arr);
-  //       Kokkos::deep_copy(xi_min_h, xi_min_arr);
-  //       Kokkos::deep_copy(xi_max_h, xi_max_arr);
-  //
-  //       ncells_t num_cells = 1u;
-  //       for (auto d { 0u }; d < M::Dim; ++d) {
-  //         i_min[d]   = std::floor(xi_min_h(d)) + N_GHOSTS;
-  //         i_max[d]   = std::ceil(xi_max_h(d)) + N_GHOSTS;
-  //         num_cells *= (i_max[d] - i_min[d]);
-  //       }
-  //
-  //       real_t dens { ZERO };
-  //       if (should_probe) {
-  //         Kokkos::parallel_reduce(
-  //           "AvgDensity",
-  //           CreateRangePolicy<M::Dim>(i_min, i_max),
-  //           kernel::ComputeSum_kernel<M::Dim, 3>(domain.fields.buff, density_buff_idx),
-  //           dens);
-  //       }
-  // #if defined(MPI_ENABLED)
-  //       real_t   tot_dens { ZERO };
-  //       ncells_t tot_num_cells { 0 };
-  //       MPI_Allreduce(&dens, &tot_dens, 1, mpi::get_type<real_t>(), MPI_SUM, MPI_COMM_WORLD);
-  //       MPI_Allreduce(&num_cells,
-  //                     &tot_num_cells,
-  //                     1,
-  //                     mpi::get_type<ncells_t>(),
-  //                     MPI_SUM,
-  //                     MPI_COMM_WORLD);
-  //       dens      = tot_dens;
-  //       num_cells = tot_num_cells;
-  // #endif
-  //       if (num_cells > 0) {
-  //         return dens / (real_t)(num_cells);
-  //       } else {
-  //         return ZERO;
-  //       }
-  //     }
-  //
-  //     auto ComputeNumInject(const SimulationParams&     params,
-  //                           const Domain<S, M>&         domain,
-  //                           real_t                      number_density,
-  //                           const boundaries_t<real_t>& box) const
-  //       -> std::tuple<bool, npart_t, array_t<real_t*>, array_t<real_t*>> override {
-  //       const auto computed_avg_density = ComputeAvgDensity(params, domain);
-  //
-  //       const auto result = this->DeduceRegion(domain, box);
-  //       if (not std::get<0>(result)) {
-  //         return { false, (npart_t)0, array_t<real_t*> {}, array_t<real_t*> {} };
-  //       }
-  //
-  //       const auto xi_min   = std::get<1>(result);
-  //       const auto xi_max   = std::get<2>(result);
-  //       auto       xi_min_h = Kokkos::create_mirror_view(xi_min);
-  //       auto       xi_max_h = Kokkos::create_mirror_view(xi_max);
-  //       Kokkos::deep_copy(xi_min_h, xi_min);
-  //       Kokkos::deep_copy(xi_max_h, xi_max);
-  //
-  //       long double num_cells { 1.0 };
-  //       for (auto d { 0u }; d < M::Dim; ++d) {
-  //         num_cells *= static_cast<long double>(xi_max_h(d)) -
-  //                      static_cast<long double>(xi_min_h(d));
-  //       }
-  //
-  //       const auto ppc0 = params.template get<real_t>("particles.ppc0");
-  //       npart_t    nparticles { 0u };
-  //       if (number_density > computed_avg_density) {
-  //         nparticles = static_cast<npart_t>(
-  //           (long double)(ppc0 * (number_density - computed_avg_density) * 0.5) *
-  //           num_cells);
-  //       }
-  //
-  //       return { nparticles != 0u, nparticles, xi_min, xi_max };
-  //     }
-  //   };
-
-  template <SimEngine::type S,
-            class M,
-            template <SimEngine::type, class> class ED,
-            template <SimEngine::type, class> class SD>
-  struct NonUniformInjector {
-    using energy_dist_t  = ED<S, M>;
-    using spatial_dist_t = SD<S, M>;
-    static_assert(M::is_metric, "M must be a metric class");
-    static_assert(energy_dist_t::is_energy_dist,
-                  "E must be an energy distribution class");
-    static_assert(spatial_dist_t::is_spatial_dist,
-                  "SD must be a spatial distribution class");
-    static constexpr bool      is_nonuniform_injector { true };
-    static constexpr Dimension D { M::Dim };
-    static constexpr Coord     C { M::CoordType };
-
-    const energy_dist_t               energy_dist;
-    const spatial_dist_t              spatial_dist;
-    const std::pair<spidx_t, spidx_t> species;
-
-    NonUniformInjector(const energy_dist_t&               energy_dist,
-                       const spatial_dist_t&              spatial_dist,
-                       const std::pair<spidx_t, spidx_t>& species)
-      : energy_dist { energy_dist }
-      , spatial_dist { spatial_dist }
-      , species { species } {}
-
-    ~NonUniformInjector() = default;
-  };
-
-  template <SimEngine::type S, class M, bool P, in O>
-  struct AtmosphereInjector {
-    struct TargetDensityProfile {
-      const real_t nmax, height, xsurf, ds;
-
-      TargetDensityProfile(real_t nmax, real_t height, real_t xsurf, real_t ds)
-        : nmax { nmax }
-        , height { height }
-        , xsurf { xsurf }
-        , ds { ds } {}
-
-      Inline auto operator()(const coord_t<M::Dim>& x_Ph) const -> real_t {
-        if constexpr ((O == in::x1) or
-                      (O == in::x2 and (M::Dim == Dim::_2D or M::Dim == Dim::_3D)) or
-                      (O == in::x3 and M::Dim == Dim::_3D)) {
-          const auto xi = x_Ph[static_cast<dim_t>(O)];
-          if constexpr (P) {
-            // + direction
-            if (xi < xsurf - ds or xi >= xsurf) {
-              return ZERO;
-            } else {
-              if constexpr (M::CoordType == Coord::Cart) {
-                return nmax * math::exp(-(xsurf - xi) / height);
-              } else {
-                raise::KernelError(
-                  HERE,
-                  "Atmosphere in +x cannot be applied for non-cartesian");
-                return ZERO;
-              }
-            }
-          } else {
-            // - direction
-            if (xi < xsurf or xi >= xsurf + ds) {
-              return ZERO;
-            } else {
-              if constexpr (M::CoordType == Coord::Cart) {
-                return nmax * math::exp(-(xi - xsurf) / height);
-              } else {
-                return nmax * math::exp(-(xsurf / height) * (ONE - (xsurf / xi)));
-              }
-            }
-          }
-        } else {
-          raise::KernelError(HERE, "Wrong direction");
-          return ZERO;
-        }
-      }
-    };
-
-    using energy_dist_t  = Maxwellian<S, M>;
-    using spatial_dist_t = Replenish<S, M, TargetDensityProfile>;
-    static_assert(M::is_metric, "M must be a metric class");
-    static constexpr bool      is_nonuniform_injector { true };
-    static constexpr Dimension D { M::Dim };
-    static constexpr Coord     C { M::CoordType };
-
-    const energy_dist_t               energy_dist;
-    const TargetDensityProfile        target_density;
-    const spatial_dist_t              spatial_dist;
-    const std::pair<spidx_t, spidx_t> species;
-
-    AtmosphereInjector(const M&                           metric,
-                       const ndfield_t<M::Dim, 6>&        density,
-                       real_t                             nmax,
-                       real_t                             height,
-                       real_t                             xsurf,
-                       real_t                             ds,
-                       real_t                             T,
-                       random_number_pool_t&              pool,
-                       const std::pair<spidx_t, spidx_t>& species)
-      : energy_dist { metric, pool, T }
-      , target_density { nmax, height, xsurf, ds }
-      , spatial_dist { metric, density, 0, target_density, nmax }
-      , species { species } {}
-
-    ~AtmosphereInjector() = default;
-  };
-
-  template <SimEngine::type S, class M, in O>
-  struct MovingInjector {
-    struct TargetDensityProfile {
-      const real_t nmax, xinj, xdrift;
-
-      TargetDensityProfile(real_t xinj, real_t xdrift, real_t nmax)
-        : xinj { xinj }
-        , xdrift { xdrift }
-        , nmax { nmax } {}
-
-      Inline auto operator()(const coord_t<M::Dim>& x_Ph) const -> real_t {
-        if constexpr ((O == in::x1) or
-                      (O == in::x2 and (M::Dim == Dim::_2D or M::Dim == Dim::_3D)) or
-                      (O == in::x3 and M::Dim == Dim::_3D)) {
-          const auto xi = x_Ph[static_cast<dim_t>(O)];
+    Inline auto operator()(const coord_t<D>& x_Ph) const -> real_t {
+      if constexpr ((O == in::x1) or
+                    (O == in::x2 and (D == Dim::_2D or D == Dim::_3D)) or
+                    (O == in::x3 and D == Dim::_3D)) {
+        const auto xi = x_Ph[static_cast<dim_t>(O)];
+        if constexpr (P) {
           // + direction
-          if (xi < xdrift or xi >= xinj) {
+          if (xi < xsurf - ds or xi >= xsurf) {
             return ZERO;
           } else {
-            if constexpr (M::CoordType == Coord::Cart) {
-              return nmax;
+            if constexpr (C == Coord::Cart) {
+              return nmax * math::exp(-(xsurf - xi) / height);
             } else {
               raise::KernelError(
                 HERE,
-                "Moving injector in +x cannot be applied for non-cartesian");
+                "Atmosphere in +x cannot be applied for non-cartesian");
               return ZERO;
             }
           }
         } else {
-          raise::KernelError(HERE, "Wrong direction");
-          return ZERO;
+          // - direction
+          if (xi < xsurf or xi >= xsurf + ds) {
+            return ZERO;
+          } else {
+            if constexpr (C == Coord::Cart) {
+              return nmax * math::exp(-(xi - xsurf) / height);
+            } else {
+              return nmax * math::exp(-(xsurf / height) * (ONE - (xsurf / xi)));
+            }
+          }
         }
+      } else {
+        raise::KernelError(HERE, "Wrong direction");
+        return ZERO;
       }
-    };
-
-    using energy_dist_t  = Maxwellian<S, M>;
-    using spatial_dist_t = Replenish<S, M, TargetDensityProfile>;
-    static_assert(M::is_metric, "M must be a metric class");
-    static constexpr bool      is_nonuniform_injector { true };
-    static constexpr Dimension D { M::Dim };
-    static constexpr Coord     C { M::CoordType };
-
-    const energy_dist_t               energy_dist;
-    const TargetDensityProfile        target_density;
-    const spatial_dist_t              spatial_dist;
-    const std::pair<spidx_t, spidx_t> species;
-
-    MovingInjector(const M&                           metric,
-                   const ndfield_t<M::Dim, 6>&        density,
-                   const energy_dist_t&               energy_dist,
-                   real_t                             xinj,
-                   real_t                             xdrift,
-                   real_t                             nmax,
-                   const std::pair<spidx_t, spidx_t>& species)
-      : energy_dist { energy_dist }
-      , target_density { xinj, xdrift, nmax }
-      , spatial_dist { metric, density, 0, target_density, nmax }
-      , species { species } {}
-
-    ~MovingInjector() = default;
-  };
-
-  // /**
-  //  * @brief Injects uniform number density of particles everywhere in the domain
-  //  * @param domain Domain object
-  //  * @param injector Uniform injector object
-  //  * @param number_density Total number density (in units of n0)
-  //  * @param use_weights Use weights
-  //  * @param box Region to inject the particles in global coords
-  //  * @tparam S Simulation engine type
-  //  * @tparam M Metric type
-  //  * @tparam I Injector type
-  //  */
-  // template <SimEngine::type S, class M, class I>
-  // inline void InjectUniform(const SimulationParams&     params,
-  //                           Domain<S, M>&               domain,
-  //                           const I&                    injector,
-  //                           real_t                      number_density,
-  //                           bool                        use_weights = false,
-  //                           const boundaries_t<real_t>& box         = {}) {
-  //   static_assert(M::is_metric, "M must be a metric class");
-  //   static_assert(I::is_uniform_injector, "I must be a uniform injector class");
-  //   raise::ErrorIf((M::CoordType != Coord::Cart) && (not use_weights),
-  //                  "Weights must be used for non-Cartesian coordinates",
-  //                  HERE);
-  //   raise::ErrorIf((M::CoordType == Coord::Cart) && use_weights,
-  //                  "Weights should not be used for Cartesian coordinates",
-  //                  HERE);
-  //   raise::ErrorIf(params.template get<bool>("particles.use_weights") != use_weights,
-  //                  "Weights must be enabled from the input file to use them in "
-  //                  "the injector",
-  //                  HERE);
-  //   if (domain.species[injector.species.first - 1].charge() +
-  //         domain.species[injector.species.second - 1].charge() !=
-  //       0.0f) {
-  //     raise::Warning("Total charge of the injected species is non-zero", HERE);
-  //   }
-  //
-  //   {
-  //     boundaries_t<real_t> nonempty_box;
-  //     for (auto d { 0u }; d < M::Dim; ++d) {
-  //       if (d < box.size()) {
-  //         nonempty_box.push_back({ box[d].first, box[d].second });
-  //       } else {
-  //         nonempty_box.push_back(Range::All);
-  //       }
-  //     }
-  //     const auto result = injector.ComputeNumInject(params,
-  //                                                   domain,
-  //                                                   number_density,
-  //                                                   nonempty_box);
-  //     if (not std::get<0>(result)) {
-  //       return;
-  //     }
-  //     const auto nparticles = std::get<1>(result);
-  //     const auto xi_min     = std::get<2>(result);
-  //     const auto xi_max     = std::get<3>(result);
-  //
-  //     Kokkos::parallel_for(
-  //       "InjectUniform",
-  //       nparticles,
-  //       kernel::UniformInjector_kernel<S, M, typename I::energy_dist_t>(
-  //         injector.species.first,
-  //         injector.species.second,
-  //         domain.species[injector.species.first - 1],
-  //         domain.species[injector.species.second - 1],
-  //         domain.species[injector.species.first - 1].npart(),
-  //         domain.species[injector.species.second - 1].npart(),
-  //         domain.mesh.metric,
-  //         xi_min,
-  //         xi_max,
-  //         injector.energy_dist,
-  //         ONE / params.template get<real_t>("scales.V0"),
-  //         domain.random_pool));
-  //     domain.species[injector.species.first - 1].set_npart(
-  //       domain.species[injector.species.first - 1].npart() + nparticles);
-  //     domain.species[injector.species.second - 1].set_npart(
-  //       domain.species[injector.species.second - 1].npart() + nparticles);
-  //   }
-  // }
-  //
-  // namespace experimental {
-
-  template <SimEngine::type S,
-            class M,
-            template <SimEngine::type, class> class ED1,
-            template <SimEngine::type, class> class ED2>
-  struct UniformInjector : BaseInjector<S, M> {
-    using energy_dist_1_t = ED1<S, M>;
-    using energy_dist_2_t = ED2<S, M>;
-    static_assert(M::is_metric, "M must be a metric class");
-    static_assert(energy_dist_1_t::is_energy_dist,
-                  "ED1 must be an energy distribution class");
-    static_assert(energy_dist_2_t::is_energy_dist,
-                  "ED2 must be an energy distribution class");
-    static constexpr bool      is_uniform_injector { true };
-    static constexpr Dimension D { M::Dim };
-    static constexpr Coord     C { M::CoordType };
-
-    const energy_dist_1_t             energy_dist_1;
-    const energy_dist_2_t             energy_dist_2;
-    const std::pair<spidx_t, spidx_t> species;
-
-    UniformInjector(const energy_dist_1_t&             energy_dist_1,
-                    const energy_dist_2_t&             energy_dist_2,
-                    const std::pair<spidx_t, spidx_t>& species)
-      : energy_dist_1 { energy_dist_1 }
-      , energy_dist_2 { energy_dist_2 }
-      , species { species } {}
-
-    ~UniformInjector() = default;
+    }
   };
 
   /**
    * @brief Injects uniform number density of particles everywhere in the domain
    * @param domain Domain object
-   * @param injector Uniform injector object
+   * @param species Pair of species indices
+   * @param energy_dists Pair of energy distribution objects
    * @param number_density Total number density (in units of n0)
    * @param use_weights Use weights
    * @param box Region to inject the particles in global coords
    * @tparam S Simulation engine type
    * @tparam M Metric type
-   * @tparam I Injector type
+   * @tparam ED1 Energy distribution type for species 1
+   * @tparam ED2 Energy distribution type for species 2
    */
-  template <SimEngine::type S, class M, class I>
-  inline void InjectUniform(const SimulationParams&     params,
-                            Domain<S, M>&               domain,
-                            const I&                    injector,
-                            real_t                      number_density,
+  template <SimEngine::type S, class M, class ED1, class ED2>
+  inline void InjectUniform(const SimulationParams&            params,
+                            Domain<S, M>&                      domain,
+                            const std::pair<spidx_t, spidx_t>& species,
+                            const std::pair<ED1, ED2>&         energy_dists,
+                            real_t                             number_density,
                             bool                        use_weights = false,
                             const boundaries_t<real_t>& box         = {}) {
     static_assert(M::is_metric, "M must be a metric class");
-    static_assert(I::is_uniform_injector, "I must be a uniform injector class");
+    static_assert(ED1::is_energy_dist, "ED1 must be an energy distribution class");
+    static_assert(ED2::is_energy_dist, "ED2 must be an energy distribution class");
     raise::ErrorIf((M::CoordType != Coord::Cart) && (not use_weights),
                    "Weights must be used for non-Cartesian coordinates",
                    HERE);
@@ -563,8 +218,8 @@ namespace arch {
                    "Weights must be enabled from the input file to use them in "
                    "the injector",
                    HERE);
-    if (domain.species[injector.species.first - 1].charge() +
-          domain.species[injector.species.second - 1].charge() !=
+    if (domain.species[species.first - 1].charge() +
+          domain.species[species.second - 1].charge() !=
         0.0f) {
       raise::Warning("Total charge of the injected species is non-zero", HERE);
     }
@@ -578,10 +233,7 @@ namespace arch {
           nonempty_box.push_back(Range::All);
         }
       }
-      const auto result = injector.ComputeNumInject(params,
-                                                    domain,
-                                                    number_density,
-                                                    nonempty_box);
+      const auto result = ComputeNumInject(params, domain, number_density, nonempty_box);
       if (not std::get<0>(result)) {
         return;
       }
@@ -589,33 +241,30 @@ namespace arch {
       const auto xi_min     = std::get<2>(result);
       const auto xi_max     = std::get<3>(result);
 
-      Kokkos::parallel_for(
-        "InjectUniform",
-        nparticles,
-        kernel::UniformInjector_kernel<S, M, typename I::energy_dist_1_t, typename I::energy_dist_2_t>(
-          injector.species.first,
-          injector.species.second,
-          domain.species[injector.species.first - 1],
-          domain.species[injector.species.second - 1],
-          nparticles,
-          domain.index(),
-          domain.species[injector.species.first - 1].npart(),
-          domain.species[injector.species.second - 1].npart(),
-          domain.mesh.metric,
-          xi_min,
-          xi_max,
-          injector.energy_dist_1,
-          injector.energy_dist_2,
-          ONE / params.template get<real_t>("scales.V0"),
-          domain.random_pool));
-      domain.species[injector.species.first - 1].set_npart(
-        domain.species[injector.species.first - 1].npart() + nparticles);
-      domain.species[injector.species.second - 1].set_npart(
-        domain.species[injector.species.second - 1].npart() + nparticles);
+      Kokkos::parallel_for("InjectUniform",
+                           nparticles,
+                           kernel::UniformInjector_kernel<S, M, ED1, ED2>(
+                             species.first,
+                             species.second,
+                             domain.species[species.first - 1],
+                             domain.species[species.second - 1],
+                             nparticles,
+                             domain.index(),
+                             domain.species[species.first - 1].npart(),
+                             domain.species[species.second - 1].npart(),
+                             domain.mesh.metric,
+                             xi_min,
+                             xi_max,
+                             energy_dists.first,
+                             energy_dists.second,
+                             ONE / params.template get<real_t>("scales.V0"),
+                             domain.random_pool));
+      domain.species[species.first - 1].set_npart(
+        domain.species[species.first - 1].npart() + nparticles);
+      domain.species[species.second - 1].set_npart(
+        domain.species[species.second - 1].npart() + nparticles);
     }
   }
-
-  // } // namespace experimental
 
   /**
    * @brief Injects particles from a globally-defined map
@@ -651,21 +300,31 @@ namespace arch {
    * @brief Injects particles based on spatial distribution function
    * @param params Simulation parameters
    * @param domain Local domain object
-   * @param injector Non-uniform injector object
+   * @param species Pair of species indices
+   * @param energy_dists Pair of energy distribution objects
+   * @param spatial_dist Spatial distribution object
    * @param number_density Total number density (in units of n0)
    * @param use_weights Use weights
    * @param box Region to inject the particles in
+   * @tparam S Simulation engine type
+   * @tparam M Metric type
+   * @tparam ED1 Energy distribution type for species 1
+   * @tparam ED2 Energy distribution type for species 2
+   * @tparam SD Spatial distribution type
    */
-  template <SimEngine::type S, class M, class I>
-  inline void InjectNonUniform(const SimulationParams&     params,
-                               Domain<S, M>&               domain,
-                               const I&                    injector,
+  template <SimEngine::type S, class M, class ED1, class ED2, class SD>
+  inline void InjectNonUniform(const SimulationParams&            params,
+                               Domain<S, M>&                      domain,
+                               const std::pair<spidx_t, spidx_t>& species,
+                               const std::pair<ED1, ED2>&         energy_dists,
+                               const SD&                          spatial_dist,
                                real_t                      number_density,
                                bool                        use_weights = false,
                                const boundaries_t<real_t>& box         = {}) {
     static_assert(M::is_metric, "M must be a metric class");
-    static_assert(I::is_nonuniform_injector,
-                  "I must be a nonuniform injector class");
+    static_assert(ED1::is_energy_dist, "ED1 must be an energy distribution class");
+    static_assert(ED2::is_energy_dist, "ED2 must be an energy distribution class");
+    static_assert(SD::is_spatial_dist, "SD must be a spatial distribution class");
     raise::ErrorIf((M::CoordType != Coord::Cart) && (not use_weights),
                    "Weights must be used for non-Cartesian coordinates",
                    HERE);
@@ -680,8 +339,8 @@ namespace arch {
       not params.template get<bool>("particles.use_weights") and use_weights,
       "Weights are not enabled in the input but enabled in the injector",
       HERE);
-    if (domain.species[injector.species.first - 1].charge() +
-          domain.species[injector.species.second - 1].charge() !=
+    if (domain.species[species.first - 1].charge() +
+          domain.species[species.second - 1].charge() !=
         0.0f) {
       raise::Warning("Total charge of the injected species is non-zero", HERE);
     }
@@ -707,28 +366,28 @@ namespace arch {
       }
       const auto ppc = number_density *
                        params.template get<real_t>("particles.ppc0") * HALF;
-      auto injector_kernel =
-        kernel::NonUniformInjector_kernel<S, M, typename I::energy_dist_t, typename I::spatial_dist_t>(
-          ppc,
-          injector.species.first,
-          injector.species.second,
-          domain.species[injector.species.first - 1],
-          domain.species[injector.species.second - 1],
-          domain.species[injector.species.first - 1].npart(),
-          domain.species[injector.species.second - 1].npart(),
-          domain.mesh.metric,
-          injector.energy_dist,
-          injector.spatial_dist,
-          ONE / params.template get<real_t>("scales.V0"),
-          domain.random_pool);
+      auto injector_kernel = kernel::NonUniformInjector_kernel<S, M, ED1, ED2, SD>(
+        ppc,
+        species.first,
+        species.second,
+        domain.species[species.first - 1],
+        domain.species[species.second - 1],
+        domain.species[species.first - 1].npart(),
+        domain.species[species.second - 1].npart(),
+        domain.mesh.metric,
+        energy_dists.first,
+        energy_dists.second,
+        spatial_dist,
+        ONE / params.template get<real_t>("scales.V0"),
+        domain.random_pool);
       Kokkos::parallel_for("InjectNonUniformNumberDensity",
                            cell_range,
                            injector_kernel);
       const auto n_inj = injector_kernel.number_injected();
-      domain.species[injector.species.first - 1].set_npart(
-        domain.species[injector.species.first - 1].npart() + n_inj);
-      domain.species[injector.species.second - 1].set_npart(
-        domain.species[injector.species.second - 1].npart() + n_inj);
+      domain.species[species.first - 1].set_npart(
+        domain.species[species.first - 1].npart() + n_inj);
+      domain.species[species.second - 1].set_npart(
+        domain.species[species.second - 1].npart() + n_inj);
     }
   }
 

--- a/src/archetypes/particle_injector.h
+++ b/src/archetypes/particle_injector.h
@@ -244,14 +244,10 @@ namespace arch {
       Kokkos::parallel_for("InjectUniform",
                            nparticles,
                            kernel::UniformInjector_kernel<S, M, ED1, ED2>(
-                             species.first,
-                             species.second,
                              domain.species[species.first - 1],
                              domain.species[species.second - 1],
                              nparticles,
                              domain.index(),
-                             domain.species[species.first - 1].npart(),
-                             domain.species[species.second - 1].npart(),
                              domain.mesh.metric,
                              xi_min,
                              xi_max,
@@ -368,12 +364,9 @@ namespace arch {
                        params.template get<real_t>("particles.ppc0") * HALF;
       auto injector_kernel = kernel::NonUniformInjector_kernel<S, M, ED1, ED2, SD>(
         ppc,
-        species.first,
-        species.second,
         domain.species[species.first - 1],
         domain.species[species.second - 1],
-        domain.species[species.first - 1].npart(),
-        domain.species[species.second - 1].npart(),
+        domain.index(),
         domain.mesh.metric,
         energy_dists.first,
         energy_dists.second,
@@ -384,10 +377,10 @@ namespace arch {
                            cell_range,
                            injector_kernel);
       const auto n_inj = injector_kernel.number_injected();
-      domain.species[species.first - 1].set_npart(
-        domain.species[species.first - 1].npart() + n_inj);
-      domain.species[species.second - 1].set_npart(
-        domain.species[species.second - 1].npart() + n_inj);
+      for (auto sp : { species.first, species.second }) {
+        domain.species[sp - 1].set_npart(domain.species[sp - 1].npart() + n_inj);
+        domain.species[sp - 1].set_counter(domain.species[sp - 1].counter() + n_inj);
+      }
     }
   }
 

--- a/src/archetypes/utils.h
+++ b/src/archetypes/utils.h
@@ -17,6 +17,7 @@
 #include "archetypes/energy_dist.h"
 #include "archetypes/particle_injector.h"
 #include "framework/domain/domain.h"
+#include "framework/parameters.h"
 
 #include <utility>
 
@@ -60,17 +61,14 @@ namespace arch {
                                                      temperature_2,
                                                      drift_four_vels.second);
 
-    const auto injector = arch::UniformInjector<S, M, arch::Maxwellian, arch::Maxwellian>(
-      maxwellian_1,
-      maxwellian_2,
-      species);
-
-    arch::InjectUniform<S, M, decltype(injector)>(params,
-                                                  domain,
-                                                  injector,
-                                                  tot_number_density,
-                                                  use_weights,
-                                                  box);
+    arch::InjectUniform<S, M, decltype(maxwellian_1), decltype(maxwellian_2)>(
+      params,
+      domain,
+      species,
+      { maxwellian_1, maxwellian_2 },
+      tot_number_density,
+      use_weights,
+      box);
   }
 
   /**

--- a/src/engines/srpic.hpp
+++ b/src/engines/srpic.hpp
@@ -23,7 +23,9 @@
 #include "utils/timer.h"
 #include "utils/toml.h"
 
+#include "archetypes/energy_dist.h"
 #include "archetypes/particle_injector.h"
+#include "archetypes/spatial_dist.h"
 #include "framework/domain/domain.h"
 #include "framework/parameters.h"
 
@@ -1268,119 +1270,153 @@ namespace ntt {
         m_metadomain.SynchronizeFields(domain, Comm::Bckp, { 0, 1 });
       }
 
+      const auto maxwellian = arch::Maxwellian<S, M> { domain.mesh.metric,
+                                                       domain.random_pool,
+                                                       temp };
+
       if (dim == in::x1) {
         if (sign > 0) {
-          const auto atm_injector =
-            arch::AtmosphereInjector<SimEngine::SRPIC, M, true, in::x1> {
-              domain.mesh.metric,
-              domain.fields.bckp,
+          auto target_density =
+            arch::AtmosphereDensityProfile<M::Dim, M::CoordType, true, in::x1> {
               nmax,
               height,
               x_surf,
-              ds,
-              temp,
-              domain.random_pool,
-              species
+              ds
             };
-          arch::InjectNonUniform<S, M, decltype(atm_injector)>(m_params,
-                                                               domain,
-                                                               atm_injector,
-                                                               nmax,
-                                                               use_weights);
+          const auto spatial_dist = arch::Replenish<S, M, 6, decltype(target_density)> {
+            domain.mesh.metric,
+            domain.fields.bckp,
+            0,
+            target_density,
+            nmax
+          };
+          arch::InjectNonUniform<S, M, decltype(maxwellian), decltype(maxwellian), decltype(spatial_dist)>(
+            m_params,
+            domain,
+            { species.first, species.second },
+            { maxwellian, maxwellian },
+            spatial_dist,
+            nmax,
+            use_weights);
         } else {
-          const auto atm_injector =
-            arch::AtmosphereInjector<SimEngine::SRPIC, M, false, in::x1> {
-              domain.mesh.metric,
-              domain.fields.bckp,
+          auto target_density =
+            arch::AtmosphereDensityProfile<M::Dim, M::CoordType, false, in::x1> {
               nmax,
               height,
               x_surf,
-              ds,
-              temp,
-              domain.random_pool,
-              species
+              ds
             };
-          arch::InjectNonUniform<S, M, decltype(atm_injector)>(m_params,
-                                                               domain,
-                                                               atm_injector,
-                                                               nmax,
-                                                               use_weights);
+          const auto spatial_dist = arch::Replenish<S, M, 6, decltype(target_density)> {
+            domain.mesh.metric,
+            domain.fields.bckp,
+            0,
+            target_density,
+            nmax
+          };
+          arch::InjectNonUniform<S, M, decltype(maxwellian), decltype(maxwellian), decltype(spatial_dist)>(
+            m_params,
+            domain,
+            { species.first, species.second },
+            { maxwellian, maxwellian },
+            spatial_dist,
+            nmax,
+            use_weights);
         }
       } else if (dim == in::x2) {
         if (sign > 0) {
-          const auto atm_injector =
-            arch::AtmosphereInjector<SimEngine::SRPIC, M, true, in::x2> {
-              domain.mesh.metric,
-              domain.fields.bckp,
+          auto target_density =
+            arch::AtmosphereDensityProfile<M::Dim, M::CoordType, true, in::x2> {
               nmax,
               height,
               x_surf,
-              ds,
-              temp,
-              domain.random_pool,
-              species
+              ds
             };
-          arch::InjectNonUniform<S, M, decltype(atm_injector)>(m_params,
-                                                               domain,
-                                                               atm_injector,
-                                                               nmax,
-                                                               use_weights);
+          const auto spatial_dist = arch::Replenish<S, M, 6, decltype(target_density)> {
+            domain.mesh.metric,
+            domain.fields.bckp,
+            0,
+            target_density,
+            nmax
+          };
+          arch::InjectNonUniform<S, M, decltype(maxwellian), decltype(maxwellian), decltype(spatial_dist)>(
+            m_params,
+            domain,
+            { species.first, species.second },
+            { maxwellian, maxwellian },
+            spatial_dist,
+            nmax,
+            use_weights);
         } else {
-          const auto atm_injector =
-            arch::AtmosphereInjector<SimEngine::SRPIC, M, false, in::x2> {
-              domain.mesh.metric,
-              domain.fields.bckp,
+          auto target_density =
+            arch::AtmosphereDensityProfile<M::Dim, M::CoordType, false, in::x2> {
               nmax,
               height,
               x_surf,
-              ds,
-              temp,
-              domain.random_pool,
-              species
+              ds
             };
-          arch::InjectNonUniform<S, M, decltype(atm_injector)>(m_params,
-                                                               domain,
-                                                               atm_injector,
-                                                               nmax,
-                                                               use_weights);
+          const auto spatial_dist = arch::Replenish<S, M, 6, decltype(target_density)> {
+            domain.mesh.metric,
+            domain.fields.bckp,
+            0,
+            target_density,
+            nmax
+          };
+          arch::InjectNonUniform<S, M, decltype(maxwellian), decltype(maxwellian), decltype(spatial_dist)>(
+            m_params,
+            domain,
+            { species.first, species.second },
+            { maxwellian, maxwellian },
+            spatial_dist,
+            nmax,
+            use_weights);
         }
       } else if (dim == in::x3) {
         if (sign > 0) {
-          const auto atm_injector =
-            arch::AtmosphereInjector<SimEngine::SRPIC, M, true, in::x3> {
-              domain.mesh.metric,
-              domain.fields.bckp,
+          auto target_density =
+            arch::AtmosphereDensityProfile<M::Dim, M::CoordType, true, in::x3> {
               nmax,
               height,
               x_surf,
-              ds,
-              temp,
-              domain.random_pool,
-              species
+              ds
             };
-          arch::InjectNonUniform<S, M, decltype(atm_injector)>(m_params,
-                                                               domain,
-                                                               atm_injector,
-                                                               nmax,
-                                                               use_weights);
+          const auto spatial_dist = arch::Replenish<S, M, 6, decltype(target_density)> {
+            domain.mesh.metric,
+            domain.fields.bckp,
+            0,
+            target_density,
+            nmax
+          };
+          arch::InjectNonUniform<S, M, decltype(maxwellian), decltype(maxwellian), decltype(spatial_dist)>(
+            m_params,
+            domain,
+            { species.first, species.second },
+            { maxwellian, maxwellian },
+            spatial_dist,
+            nmax,
+            use_weights);
         } else {
-          const auto atm_injector =
-            arch::AtmosphereInjector<SimEngine::SRPIC, M, false, in::x3> {
-              domain.mesh.metric,
-              domain.fields.bckp,
+          auto target_density =
+            arch::AtmosphereDensityProfile<M::Dim, M::CoordType, false, in::x3> {
               nmax,
               height,
               x_surf,
-              ds,
-              temp,
-              domain.random_pool,
-              species
+              ds
             };
-          arch::InjectNonUniform<S, M, decltype(atm_injector)>(m_params,
-                                                               domain,
-                                                               atm_injector,
-                                                               nmax,
-                                                               use_weights);
+          const auto spatial_dist = arch::Replenish<S, M, 6, decltype(target_density)> {
+            domain.mesh.metric,
+            domain.fields.bckp,
+            0,
+            target_density,
+            nmax
+          };
+          arch::InjectNonUniform<S, M, decltype(maxwellian), decltype(maxwellian), decltype(spatial_dist)>(
+            m_params,
+            domain,
+            { species.first, species.second },
+            { maxwellian, maxwellian },
+            spatial_dist,
+            nmax,
+            use_weights);
         }
       } else {
         raise::Error("Invalid dimension", HERE);

--- a/src/framework/containers/particles_io.cpp
+++ b/src/framework/containers/particles_io.cpp
@@ -59,18 +59,14 @@ namespace ntt {
     }
     auto num_track_plds = 0;
     if (use_tracking()) {
+      io.DefineVariable<npart_t>(fmt::format("pIDX_%d", index()),
+                                 { adios2::UnknownDim },
+                                 { adios2::UnknownDim },
+                                 { adios2::UnknownDim });
 #if !defined(MPI_ENABLED)
       num_track_plds = 1;
-      io.DefineVariable<npart_t>(fmt::format("pIDX_%d", index()),
-                                 { adios2::UnknownDim },
-                                 { adios2::UnknownDim },
-                                 { adios2::UnknownDim });
 #else
       num_track_plds = 2;
-      io.DefineVariable<npart_t>(fmt::format("pIDX_%d", index()),
-                                 { adios2::UnknownDim },
-                                 { adios2::UnknownDim },
-                                 { adios2::UnknownDim });
       io.DefineVariable<npart_t>(fmt::format("pRNK_%d", index()),
                                  { adios2::UnknownDim },
                                  { adios2::UnknownDim },
@@ -109,7 +105,7 @@ namespace ntt {
       const auto pld_i_d = this->pld_i;
       Kokkos::parallel_reduce(
         "CountOutputParticles",
-        npart(),
+        rangeActiveParticles(),
         Lambda(index_t p, npart_t & l_nout) {
           if ((tag_d(p) == ParticleTag::alive) and
               (pld_i_d(p, pldi::spcCtr) % prtl_stride == 0)) {
@@ -121,7 +117,7 @@ namespace ntt {
       array_t<npart_t> out_counter { "out_counter" };
       Kokkos::parallel_for(
         "RecordOutputIndices",
-        npart(),
+        rangeActiveParticles(),
         Lambda(index_t p) {
           if ((tag_d(p) == ParticleTag::alive) and
               (pld_i_d(p, pldi::spcCtr) % prtl_stride == 0)) {

--- a/src/framework/containers/particles_io.cpp
+++ b/src/framework/containers/particles_io.cpp
@@ -31,7 +31,9 @@ namespace ntt {
    * * * * * * * * */
   template <Dimension D, Coord::type C>
   void Particles<D, C>::OutputDeclare(adios2::IO& io) const {
-    for (auto d { 0u }; d < D; ++d) {
+    const auto n_addition_coords = ((D == Dim::_2D) and (C != Coord::Cart)) ? 1
+                                                                            : 0;
+    for (auto d { 0u }; d < D + n_addition_coords; ++d) {
       io.DefineVariable<real_t>(fmt::format("pX%d_%d", d + 1, index()),
                                 { adios2::UnknownDim },
                                 { adios2::UnknownDim },

--- a/src/framework/domain/stats.cpp
+++ b/src/framework/domain/stats.cpp
@@ -39,8 +39,9 @@ namespace ntt {
     raise::ErrorIf(local_domain->is_placeholder(),
                    "local_domain is a placeholder",
                    HERE);
-    const auto filename = params.template get<std::string>("simulation.name") +
-                          "_stats.csv";
+    const auto simname  = params.template get<std::string>("simulation.name");
+    const auto filename = std::filesystem::path(simname) /
+                          (simname + "_stats.csv");
     const auto enable_stats = params.template get<bool>("output.stats.enable");
     if (enable_stats and (not is_resuming)) {
       CallOnce(

--- a/src/framework/simulation.cpp
+++ b/src/framework/simulation.cpp
@@ -35,6 +35,7 @@ namespace ntt {
                                                       "log_level",
                                                       defaults::diag::log_level);
     logger::initPlog<files::LogFile, files::InfoFile, files::ErrFile>(sim_name,
+                                                                      sim_name,
                                                                       log_level);
 
     m_requested_engine = SimEngine::pick(

--- a/src/global/arch/kokkos_aliases.h
+++ b/src/global/arch/kokkos_aliases.h
@@ -36,6 +36,9 @@ namespace math = Kokkos;
 template <typename T>
 using array_t = Kokkos::View<T>;
 
+template <typename T>
+using array_h_t = Kokkos::View<T, Kokkos::HostSpace>;
+
 // Array mirror alias of arbitrary type
 template <typename T>
 using array_mirror_t = typename array_t<T>::HostMirror;

--- a/src/global/arch/kokkos_aliases.h
+++ b/src/global/arch/kokkos_aliases.h
@@ -234,8 +234,8 @@ auto CreateParticleRangePolicy(npart_t, npart_t) -> range_t<Dim::_1D>;
  * @returns Kokkos::RangePolicy or Kokkos::MDRangePolicy in the accelerator execution space.
  */
 template <Dimension D>
-auto CreateRangePolicy(const tuple_t<ncells_t, D>&, const tuple_t<ncells_t, D>&)
-  -> range_t<D>;
+auto CreateRangePolicy(const tuple_t<ncells_t, D>&,
+                       const tuple_t<ncells_t, D>&) -> range_t<D>;
 
 /**
  * @brief Function template for generating ND Kokkos range policy on the host.
@@ -249,7 +249,7 @@ auto CreateRangePolicyOnHost(const tuple_t<ncells_t, D>&,
                              const tuple_t<ncells_t, D>&) -> range_h_t<D>;
 
 // Random number pool/generator type alias
-using random_number_pool_t = Kokkos::Random_XorShift1024_Pool<Kokkos::DefaultExecutionSpace>;
+using random_number_pool_t = Kokkos::Random_XorShift64_Pool<Kokkos::DefaultExecutionSpace>;
 using random_generator_t = typename random_number_pool_t::generator_type;
 
 // Random number generator functions

--- a/src/global/utils/diag.cpp
+++ b/src/global/utils/diag.cpp
@@ -4,6 +4,7 @@
 
 #include "utils/colors.h"
 #include "utils/formatting.h"
+#include "utils/log.h"
 #include "utils/progressbar.h"
 #include "utils/timer.h"
 
@@ -241,7 +242,6 @@ namespace diag {
       ss << std::setw(80) << std::setfill('.') << "" << std::endl << std::endl;
     });
 
-    std::cout << ((diag_flags & Diag::Colorful) ? ss.str()
-                                                : color::strip(ss.str()));
+    info::Print(ss.str(), diag_flags & Diag::Colorful, true, true, false);
   }
 } // namespace diag

--- a/src/global/utils/diag.cpp
+++ b/src/global/utils/diag.cpp
@@ -26,11 +26,12 @@ namespace diag {
     npart_t npart,
     npart_t maxnpart) -> std::vector<std::pair<npart_t, unsigned short>> {
     auto stats = std::vector<std::pair<npart_t, unsigned short>>();
+    const auto percentage = [](npart_t part, npart_t maxpart) -> unsigned short {
+      return static_cast<unsigned short>(
+        100.0f * static_cast<float>(part) / static_cast<float>(maxpart));
+    };
 #if !defined(MPI_ENABLED)
-    stats.push_back(
-      { npart,
-        static_cast<unsigned short>(
-          100.0f * static_cast<float>(npart) / static_cast<float>(maxnpart)) });
+    stats.push_back({ npart, percentage(npart, maxnpart) });
 #else
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -56,22 +57,18 @@ namespace diag {
     if (rank != MPI_ROOT_RANK) {
       return stats;
     }
-    auto tot_npart     = std::accumulate(mpi_npart.begin(), mpi_npart.end(), 0);
-    const auto max_idx = std::distance(
+    const npart_t tot_npart = std::accumulate(mpi_npart.begin(), mpi_npart.end(), 0u);
+    const npart_t max_idx = std::distance(
       mpi_npart.begin(),
       std::max_element(mpi_npart.begin(), mpi_npart.end()));
-    const auto min_idx = std::distance(
+    const npart_t min_idx = std::distance(
       mpi_npart.begin(),
       std::min_element(mpi_npart.begin(), mpi_npart.end()));
     stats.push_back({ tot_npart, 0u });
     stats.push_back({ mpi_npart[min_idx],
-                      static_cast<unsigned short>(
-                        100.0f * static_cast<float>(mpi_npart[min_idx]) /
-                        static_cast<float>(mpi_maxnpart[min_idx])) });
+                      percentage(mpi_npart[min_idx], mpi_maxnpart[min_idx]) });
     stats.push_back({ mpi_npart[max_idx],
-                      static_cast<unsigned short>(
-                        100.0f * static_cast<float>(mpi_npart[max_idx]) /
-                        static_cast<float>(mpi_maxnpart[max_idx])) });
+                      percentage(mpi_npart[max_idx], mpi_maxnpart[max_idx]) });
 #endif
     return stats;
   }
@@ -182,7 +179,7 @@ namespace diag {
         const auto max_pct   = part_stats[2].second;
         ss << fmt::alignedTable(
           {
-            fmt::format("species %2lu (%s)", i, species_labels[i].c_str()),
+            fmt::format("species %2lu (%s)", i + 1, species_labels[i].c_str()),
             tot_npart > 9999 ? fmt::format("%.2Le", (long double)tot_npart)
                              : std::to_string(tot_npart),
             std::to_string(min_pct) + "%",
@@ -208,7 +205,7 @@ namespace diag {
         const auto tot_pct = part_stats[0].second;
         ss << fmt::alignedTable(
           {
-            fmt::format("species %2lu (%s)", i, species_labels[i].c_str()),
+            fmt::format("species %2lu (%s)", i + 1, species_labels[i].c_str()),
             tot_npart > 9999 ? fmt::format("%.2Le", (long double)tot_npart)
                              : std::to_string(tot_npart),
             std::to_string(tot_pct) + "%",

--- a/src/global/utils/log.h
+++ b/src/global/utils/log.h
@@ -122,31 +122,37 @@ namespace info {
   inline void Print(const std::string& msg,
                     bool               colored = true,
                     bool               stdout  = true,
-                    bool               once    = true) {
+                    bool               once    = true,
+                    bool               info    = true) {
     auto msg_nocol = color::strip(msg);
     if (once) {
       CallOnce(
-        [](auto& msg, auto& msg_nocol, auto& stdout, auto& colored) {
-          PLOGN_(InfoFile) << msg_nocol << std::flush;
+        [](auto& msg, auto& msg_nocol, auto& stdout, auto& colored, auto& info) {
+          if (info) {
+            PLOGN_(InfoFile) << msg_nocol << std::flush;
+          }
           if (stdout) {
             if (colored) {
-              std::cout << msg << std::endl;
+              PLOG(plog::none) << msg << std::endl;
             } else {
-              std::cout << msg_nocol << std::endl;
+              PLOG(plog::none) << msg_nocol << std::endl;
             }
           }
         },
         msg,
         msg_nocol,
         stdout,
-        colored);
+        colored,
+        info);
     } else {
-      PLOGN_(InfoFile) << msg_nocol << std::flush;
+      if (info) {
+        PLOGN_(InfoFile) << msg_nocol << std::flush;
+      }
       if (stdout) {
         if (colored) {
-          std::cout << msg << std::endl;
+          PLOG(plog::none) << msg << std::endl;
         } else {
-          std::cout << msg_nocol << std::endl;
+          PLOG(plog::none) << msg_nocol << std::endl;
         }
       }
     }

--- a/src/global/utils/plog.h
+++ b/src/global/utils/plog.h
@@ -13,6 +13,7 @@
 #ifndef GLOBAL_UTILS_PLOG_H
 #define GLOBAL_UTILS_PLOG_H
 
+#include "utils/colors.h"
 #include "utils/formatting.h"
 
 #include <plog/Appenders/ColorConsoleAppender.h>
@@ -35,9 +36,28 @@ namespace plog {
 
     static auto format(const Record& record) -> util::nstring {
       util::nostringstream ss;
-      ss << std::setw(6) << std::left << severityToString(record.getSeverity())
-         << PLOG_NSTR(": ");
+      if (record.getSeverity() != plog::none) {
+        ss << std::setw(6) << std::left
+           << severityToString(record.getSeverity()) << PLOG_NSTR(": ");
+      }
       ss << record.getMessage() << PLOG_NSTR("\n");
+      return ss.str();
+    }
+  };
+
+  class NttStdoutFormatter {
+  public:
+    static auto header() -> util::nstring {
+      return util::nstring();
+    }
+
+    static auto format(const Record& record) -> util::nstring {
+      util::nostringstream ss;
+      if (record.getSeverity() != plog::none) {
+        ss << std::setw(6) << std::left
+           << severityToString(record.getSeverity()) << PLOG_NSTR(": ");
+      }
+      ss << color::strip(record.getMessage()) << PLOG_NSTR("\n");
       return ss.str();
     }
   };
@@ -59,26 +79,36 @@ namespace plog {
 namespace logger {
 
   template <int log_tag, int info_tag, int err_tag>
-  inline void initPlog(const std::string& fname, const std::string& log_level) {
+  inline void initPlog(const std::string& fpath,
+                       const std::string& fname,
+                       const std::string& log_level) {
     // setup logging
+    const auto outfile_name  = fname + ".out";
     const auto logfile_name  = fname + ".log";
     const auto infofile_name = fname + ".info";
     const auto errfile_name  = fname + ".err";
 
     namespace fs = std::filesystem;
-    fs::path logfile_path { logfile_name };
-    fs::path infofile_path { infofile_name };
-    fs::path errfile_path { errfile_name };
+    if (not fpath.empty() and not fs::exists(fpath)) {
+      fs::create_directory(fpath);
+    }
+    fs::path outfile_path { fs::path { fpath } / outfile_name };
+    fs::path logfile_path { fs::path { fpath } / logfile_name };
+    fs::path infofile_path { fs::path { fpath } / infofile_name };
+    fs::path errfile_path { fs::path { fpath } / errfile_name };
+    fs::remove(outfile_path);
     fs::remove(logfile_path);
     fs::remove(infofile_path);
     fs::remove(errfile_path);
 
+    static plog::RollingFileAppender<plog::NttStdoutFormatter> outfileAppender(
+      outfile_path.c_str());
     static plog::RollingFileAppender<plog::TxtFormatter> logfileAppender(
-      logfile_name.c_str());
+      logfile_path.c_str());
     static plog::RollingFileAppender<plog::NttInfoFormatter> infofileAppender(
-      infofile_name.c_str());
+      infofile_path.c_str());
     static plog::RollingFileAppender<plog::NttInfoFormatter> errfileAppender(
-      errfile_name.c_str());
+      errfile_path.c_str());
     auto log_severity = plog::verbose;
     if (fmt::toLower(log_level) == "warning") {
       log_severity = plog::warning;
@@ -96,7 +126,7 @@ namespace logger {
 #endif
 
     static plog::ColorConsoleAppender<plog::NttConsoleFormatter> consoleAppender;
-    plog::init(severity, &consoleAppender);
+    plog::init(severity, &consoleAppender).addAppender(&outfileAppender);
   }
 
 } // namespace logger

--- a/src/kernels/injectors.hpp
+++ b/src/kernels/injectors.hpp
@@ -529,11 +529,12 @@ namespace kernel {
     }
   }; // struct GlobalInjector_kernel
 
-  template <SimEngine::type S, class M, class ED, class SD>
+  template <SimEngine::type S, class M, class ED1, class ED2, class SD>
   struct NonUniformInjector_kernel {
-    static_assert(ED::is_energy_dist, "ED must be an energy distribution class");
-    static_assert(SD::is_spatial_dist, "SD must be a spatial distribution class");
     static_assert(M::is_metric, "M must be a metric class");
+    static_assert(ED1::is_energy_dist, "ED1 must be an energy distribution class");
+    static_assert(ED2::is_energy_dist, "ED2 must be an energy distribution class");
+    static_assert(SD::is_spatial_dist, "SD must be a spatial distribution class");
 
     const real_t  ppc0;
     const spidx_t spidx1, spidx2;
@@ -556,7 +557,8 @@ namespace kernel {
 
     npart_t              offset1, offset2;
     M                    metric;
-    const ED             energy_dist;
+    const ED1            energy_dist_1;
+    const ED2            energy_dist_2;
     const SD             spatial_dist;
     const real_t         inv_V0;
     random_number_pool_t random_pool;
@@ -569,7 +571,8 @@ namespace kernel {
                               npart_t                          offset1,
                               npart_t                          offset2,
                               const M&                         metric,
-                              const ED&                        energy_dist,
+                              const ED1&                       energy_dist_1,
+                              const ED2&                       energy_dist_2,
                               const SD&                        spatial_dist,
                               real_t                           inv_V0,
                               random_number_pool_t&            random_pool)
@@ -603,7 +606,8 @@ namespace kernel {
       , offset1 { offset1 }
       , offset2 { offset2 }
       , metric { metric }
-      , energy_dist { energy_dist }
+      , energy_dist_1 { energy_dist_1 }
+      , energy_dist_2 { energy_dist_2 }
       , spatial_dist { spatial_dist }
       , inv_V0 { inv_V0 }
       , random_pool { random_pool } {}
@@ -635,12 +639,12 @@ namespace kernel {
           dx1s_2(index + offset2) = dx1;
 
           vec_t<Dim::_3D> v_T { ZERO }, v_XYZ { ZERO };
-          energy_dist(x_Ph, v_T, spidx1);
+          energy_dist_1(x_Ph, v_T, spidx1);
           metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd, v_T, v_XYZ);
           ux1s_1(index + offset1) = v_XYZ[0];
           ux2s_1(index + offset1) = v_XYZ[1];
           ux3s_1(index + offset1) = v_XYZ[2];
-          energy_dist(x_Ph, v_T, spidx2);
+          energy_dist_2(x_Ph, v_T, spidx2);
           metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd, v_T, v_XYZ);
           ux1s_2(index + offset2) = v_XYZ[0];
           ux2s_2(index + offset2) = v_XYZ[1];
@@ -697,7 +701,7 @@ namespace kernel {
           dx2s_2(index + offset2) = dx2;
 
           vec_t<Dim::_3D> v_T { ZERO }, v_Cd { ZERO };
-          energy_dist(x_Ph, v_T, spidx1);
+          energy_dist_1(x_Ph, v_T, spidx1);
           if constexpr (S == SimEngine::SRPIC) {
             metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd_, v_T, v_Cd);
           } else if constexpr (S == SimEngine::GRPIC) {
@@ -706,7 +710,7 @@ namespace kernel {
           ux1s_1(index + offset1) = v_Cd[0];
           ux2s_1(index + offset1) = v_Cd[1];
           ux3s_1(index + offset1) = v_Cd[2];
-          energy_dist(x_Ph, v_T, spidx2);
+          energy_dist_2(x_Ph, v_T, spidx2);
           if constexpr (S == SimEngine::SRPIC) {
             metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd_, v_T, v_Cd);
           } else if constexpr (S == SimEngine::GRPIC) {
@@ -770,7 +774,7 @@ namespace kernel {
           dx3s_2(index + offset2) = dx3;
 
           vec_t<Dim::_3D> v_T { ZERO }, v_Cd { ZERO };
-          energy_dist(x_Ph, v_T, spidx1);
+          energy_dist_1(x_Ph, v_T, spidx1);
           if constexpr (S == SimEngine::SRPIC) {
             metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd, v_T, v_Cd);
           } else if constexpr (S == SimEngine::GRPIC) {
@@ -779,7 +783,7 @@ namespace kernel {
           ux1s_1(index + offset1) = v_Cd[0];
           ux2s_1(index + offset1) = v_Cd[1];
           ux3s_1(index + offset1) = v_Cd[2];
-          energy_dist(x_Ph, v_T, spidx2);
+          energy_dist_2(x_Ph, v_T, spidx2);
           if constexpr (S == SimEngine::SRPIC) {
             metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd, v_T, v_Cd);
           } else if constexpr (S == SimEngine::GRPIC) {

--- a/src/kernels/injectors.hpp
+++ b/src/kernels/injectors.hpp
@@ -81,8 +81,6 @@ namespace kernel {
     static_assert(ED2::is_energy_dist, "ED2 must be an energy distribution class");
     static_assert(M::is_metric, "M must be a metric class");
 
-    const spidx_t spidx1, spidx2;
-
     array_t<int*>      i1s_1, i2s_1, i3s_1;
     array_t<prtldx_t*> dx1s_1, dx2s_1, dx3s_1;
     array_t<real_t*>   ux1s_1, ux2s_1, ux3s_1;
@@ -99,9 +97,9 @@ namespace kernel {
     array_t<short*>    tags_2;
     array_t<npart_t**> pldis_2;
 
-    npart_t                offset1, offset2;
-    npart_t                domain_idx, cntr1, cntr2;
-    bool                   use_tracking_1, use_tracking_2;
+    const npart_t          offset1, offset2;
+    const npart_t          domain_idx, cntr1, cntr2;
+    const bool             use_tracking_1, use_tracking_2;
     const M                metric;
     const array_t<real_t*> xi_min, xi_max;
     const ED1              energy_dist_1;
@@ -109,14 +107,10 @@ namespace kernel {
     const real_t           inv_V0;
     random_number_pool_t   random_pool;
 
-    UniformInjector_kernel(spidx_t                          spidx1,
-                           spidx_t                          spidx2,
-                           Particles<M::Dim, M::CoordType>& species1,
+    UniformInjector_kernel(Particles<M::Dim, M::CoordType>& species1,
                            Particles<M::Dim, M::CoordType>& species2,
                            npart_t                          inject_npart,
                            npart_t                          domain_idx,
-                           npart_t                          offset1,
-                           npart_t                          offset2,
                            const M&                         metric,
                            const array_t<real_t*>&          xi_min,
                            const array_t<real_t*>&          xi_max,
@@ -124,9 +118,7 @@ namespace kernel {
                            const ED2&                       energy_dist_2,
                            real_t                           inv_V0,
                            random_number_pool_t&            random_pool)
-      : spidx1 { spidx1 }
-      , spidx2 { spidx2 }
-      , i1s_1 { species1.i1 }
+      : i1s_1 { species1.i1 }
       , i2s_1 { species1.i2 }
       , i3s_1 { species1.i3 }
       , dx1s_1 { species1.dx1 }
@@ -152,13 +144,13 @@ namespace kernel {
       , weights_2 { species2.weight }
       , tags_2 { species2.tag }
       , pldis_2 { species2.pld_i }
-      , offset1 { offset1 }
-      , offset2 { offset2 }
-      , use_tracking_1 { species1.use_tracking() }
-      , use_tracking_2 { species2.use_tracking() }
+      , offset1 { species1.npart() }
+      , offset2 { species2.npart() }
       , domain_idx { domain_idx }
       , cntr1 { species1.counter() }
       , cntr2 { species2.counter() }
+      , use_tracking_1 { species1.use_tracking() }
+      , use_tracking_2 { species2.use_tracking() }
       , metric { metric }
       , xi_min { xi_min }
       , xi_max { xi_max }
@@ -167,7 +159,6 @@ namespace kernel {
       , inv_V0 { inv_V0 }
       , random_pool { random_pool } {
       if (use_tracking_1) {
-        printf("using tracking for  species #1\n");
         species1.set_counter(cntr1 + inject_npart);
 #if !defined(MPI_ENABLED)
         raise::ErrorIf(species1.pld_i.extent(1) < 1,
@@ -184,7 +175,6 @@ namespace kernel {
 #endif
       }
       if (use_tracking_2) {
-        printf("using tracking for  species #2\n");
         species2.set_counter(cntr2 + inject_npart);
 #if !defined(MPI_ENABLED)
         raise::ErrorIf(species2.pld_i.extent(1) < 1,
@@ -232,34 +222,34 @@ namespace kernel {
         coord_t<M::Dim> x_Ph { ZERO };
         metric.template convert<Crd::Cd, Crd::Ph>(x_Cd, x_Ph);
         if constexpr (M::CoordType == Coord::Cart) {
-          energy_dist_1(x_Ph, v1, spidx1);
-          energy_dist_2(x_Ph, v2, spidx2);
+          energy_dist_1(x_Ph, v1);
+          energy_dist_2(x_Ph, v2);
         } else if constexpr (S == SimEngine::SRPIC) {
           coord_t<M::PrtlDim> x_Cd_ { ZERO };
           x_Cd_[0] = x_Cd[0];
           x_Cd_[1] = x_Cd[1];
           x_Cd_[2] = ZERO; // phi = 0
           vec_t<Dim::_3D> v_Ph { ZERO };
-          energy_dist_1(x_Ph, v_Ph, spidx1);
+          energy_dist_1(x_Ph, v_Ph);
           metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd_, v_Ph, v1);
-          energy_dist_2(x_Ph, v_Ph, spidx2);
+          energy_dist_2(x_Ph, v_Ph);
           metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd_, v_Ph, v2);
         } else if constexpr (S == SimEngine::GRPIC) {
           vec_t<Dim::_3D> v_Ph { ZERO };
-          energy_dist_1(x_Ph, v_Ph, spidx1);
+          energy_dist_1(x_Ph, v_Ph);
           metric.template transform<Idx::T, Idx::D>(x_Cd, v_Ph, v1);
-          energy_dist_2(x_Ph, v_Ph, spidx2);
+          energy_dist_2(x_Ph, v_Ph);
           metric.template transform<Idx::T, Idx::D>(x_Cd, v_Ph, v2);
         } else {
           raise::KernelError(HERE, "Unknown simulation engine");
         }
       }
-      // clang-format off
       real_t weight = ONE;
       if constexpr (M::CoordType != Coord::Cart) {
-        const auto sqrt_det_h  = metric.sqrt_det_h(x_Cd);
-        weight = sqrt_det_h * inv_V0;
+        const auto sqrt_det_h = metric.sqrt_det_h(x_Cd);
+        weight                = sqrt_det_h * inv_V0;
       }
+      // clang-format off
       if (not use_tracking_1) {
         InjectParticle<M::Dim, M::CoordType, false>(
           p + offset1, 
@@ -275,7 +265,8 @@ namespace kernel {
           dx1s_1, dx2s_1, dx3s_1,
           ux1s_1, ux2s_1, ux3s_1,
           phis_1, weights_1, tags_1, pldis_1,
-          xi_Cd, dxi_Cd, v1, weight, ZERO, domain_idx, cntr1 + p);
+          xi_Cd, dxi_Cd, v1, weight, ZERO, 
+          domain_idx, cntr1 + p);
       }
       if (not use_tracking_2) {
         InjectParticle<M::Dim, M::CoordType, false>(
@@ -292,7 +283,8 @@ namespace kernel {
           dx1s_2, dx2s_2, dx3s_2,
           ux1s_2, ux2s_2, ux3s_2,
           phis_2, weights_2, tags_2, pldis_2,
-          xi_Cd, dxi_Cd, v2, weight, ZERO, domain_idx, cntr2 + p);
+          xi_Cd, dxi_Cd, v2, weight, ZERO, 
+          domain_idx, cntr2 + p);
       }
       // clang-format on
     }
@@ -536,8 +528,7 @@ namespace kernel {
     static_assert(ED2::is_energy_dist, "ED2 must be an energy distribution class");
     static_assert(SD::is_spatial_dist, "SD must be a spatial distribution class");
 
-    const real_t  ppc0;
-    const spidx_t spidx1, spidx2;
+    const real_t ppc0;
 
     array_t<int*>      i1s_1, i2s_1, i3s_1;
     array_t<prtldx_t*> dx1s_1, dx2s_1, dx3s_1;
@@ -545,6 +536,7 @@ namespace kernel {
     array_t<real_t*>   phis_1;
     array_t<real_t*>   weights_1;
     array_t<short*>    tags_1;
+    array_t<npart_t**> pldis_1;
 
     array_t<int*>      i1s_2, i2s_2, i3s_2;
     array_t<prtldx_t*> dx1s_2, dx2s_2, dx3s_2;
@@ -552,11 +544,14 @@ namespace kernel {
     array_t<real_t*>   phis_2;
     array_t<real_t*>   weights_2;
     array_t<short*>    tags_2;
+    array_t<npart_t**> pldis_2;
 
     array_t<npart_t> idx { "idx" };
 
-    npart_t              offset1, offset2;
-    M                    metric;
+    const npart_t        offset1, offset2;
+    const npart_t        domain_idx, cntr1, cntr2;
+    const bool           use_tracking_1, use_tracking_2;
+    const M              metric;
     const ED1            energy_dist_1;
     const ED2            energy_dist_2;
     const SD             spatial_dist;
@@ -564,12 +559,9 @@ namespace kernel {
     random_number_pool_t random_pool;
 
     NonUniformInjector_kernel(real_t                           ppc0,
-                              spidx_t                          spidx1,
-                              spidx_t                          spidx2,
                               Particles<M::Dim, M::CoordType>& species1,
                               Particles<M::Dim, M::CoordType>& species2,
-                              npart_t                          offset1,
-                              npart_t                          offset2,
+                              npart_t                          domain_idx,
                               const M&                         metric,
                               const ED1&                       energy_dist_1,
                               const ED2&                       energy_dist_2,
@@ -577,8 +569,6 @@ namespace kernel {
                               real_t                           inv_V0,
                               random_number_pool_t&            random_pool)
       : ppc0 { ppc0 }
-      , spidx1 { spidx1 }
-      , spidx2 { spidx2 }
       , i1s_1 { species1.i1 }
       , i2s_1 { species1.i2 }
       , i3s_1 { species1.i3 }
@@ -591,6 +581,7 @@ namespace kernel {
       , phis_1 { species1.phi }
       , weights_1 { species1.weight }
       , tags_1 { species1.tag }
+      , pldis_1 { species1.pld_i }
       , i1s_2 { species2.i1 }
       , i2s_2 { species2.i2 }
       , i3s_2 { species2.i3 }
@@ -603,8 +594,14 @@ namespace kernel {
       , phis_2 { species2.phi }
       , weights_2 { species2.weight }
       , tags_2 { species2.tag }
-      , offset1 { offset1 }
-      , offset2 { offset2 }
+      , pldis_2 { species2.pld_i }
+      , offset1 { species1.npart() }
+      , offset2 { species2.npart() }
+      , domain_idx { domain_idx }
+      , cntr1 { species1.counter() }
+      , cntr2 { species2.counter() }
+      , use_tracking_1 { species1.use_tracking() }
+      , use_tracking_2 { species2.use_tracking() }
       , metric { metric }
       , energy_dist_1 { energy_dist_1 }
       , energy_dist_2 { energy_dist_2 }
@@ -618,50 +615,94 @@ namespace kernel {
       return idx_h();
     }
 
+    Inline void inject1(const index_t&                   index,
+                        const tuple_t<int, M::Dim>&      xi_Cd,
+                        const tuple_t<prtldx_t, M::Dim>& dxi_Cd,
+                        const vec_t<Dim::_3D>&           v_Cd,
+                        const real_t&                    weight) const {
+      // clang-format off
+      if (not use_tracking_1) {
+        InjectParticle<M::Dim, M::CoordType, false>(index + offset1,
+                                                    i1s_1, i2s_1, i3s_1,
+                                                    dx1s_1, dx2s_1, dx3s_1,
+                                                    ux1s_1, ux2s_1, ux3s_1,
+                                                    phis_1, weights_1, tags_1, pldis_1,
+                                                    xi_Cd, dxi_Cd, v_Cd, weight, ZERO);
+      } else {
+        InjectParticle<M::Dim, M::CoordType, true>(index + offset1,
+                                                   i1s_1, i2s_1, i3s_1,
+                                                   dx1s_1, dx2s_1, dx3s_1,
+                                                   ux1s_1, ux2s_1, ux3s_1,
+                                                   phis_1, weights_1, tags_1, pldis_1,
+                                                   xi_Cd, dxi_Cd, v_Cd, weight, ZERO,
+                                                   domain_idx, index + cntr1);
+      }
+      // clang-format on
+    }
+
+    Inline void inject2(const index_t&                   index,
+                        const tuple_t<int, M::Dim>&      xi_Cd,
+                        const tuple_t<prtldx_t, M::Dim>& dxi_Cd,
+                        const vec_t<Dim::_3D>&           v_Cd,
+                        const real_t&                    weight) const {
+      // clang-format off
+      if (not use_tracking_2) {
+        InjectParticle<M::Dim, M::CoordType, false>(index + offset1,
+                                                    i1s_2, i2s_2, i3s_2,
+                                                    dx1s_2, dx2s_2, dx3s_2,
+                                                    ux1s_2, ux2s_2, ux3s_2,
+                                                    phis_2, weights_2, tags_2, pldis_2,
+                                                    xi_Cd, dxi_Cd, v_Cd, weight, ZERO);
+      } else {
+        InjectParticle<M::Dim, M::CoordType, true>(index + offset1,
+                                                   i1s_2, i2s_2, i3s_2,
+                                                   dx1s_2, dx2s_2, dx3s_2,
+                                                   ux1s_2, ux2s_2, ux3s_2,
+                                                   phis_2, weights_2, tags_2, pldis_2,
+                                                   xi_Cd, dxi_Cd, v_Cd, weight, ZERO,
+                                                   domain_idx, index + cntr1);
+      }
+      // clang-format on
+    }
+
     Inline void operator()(index_t i1) const {
       if constexpr (M::Dim == Dim::_1D) {
         const auto        i1_ = COORD(i1);
         coord_t<Dim::_1D> x_Cd { i1_ + HALF };
         coord_t<Dim::_1D> x_Ph { ZERO };
         metric.template convert<Crd::Cd, Crd::Ph>(x_Cd, x_Ph);
+
         const auto ppc = static_cast<npart_t>(ppc0 * spatial_dist(x_Ph));
         if (ppc == 0) {
           return;
         }
-        auto rand_gen = random_pool.get_state();
+
+        auto weight = ONE;
+        if constexpr (M::CoordType != Coord::Cart) {
+          weight = metric.sqrt_det_h({ i1_ + HALF }) * inv_V0;
+        }
         for (auto p { 0u }; p < ppc; ++p) {
           const auto index = Kokkos::atomic_fetch_add(&idx(), 1);
-          const auto dx1   = Random<prtldx_t>(rand_gen);
 
-          i1s_1(index + offset1)  = static_cast<int>(i1) - N_GHOSTS;
-          dx1s_1(index + offset1) = dx1;
-          i1s_2(index + offset2)  = static_cast<int>(i1) - N_GHOSTS;
-          dx1s_2(index + offset2) = dx1;
+          auto       rand_gen = random_pool.get_state();
+          const auto dx1      = Random<prtldx_t>(rand_gen);
+          random_pool.free_state(rand_gen);
 
-          vec_t<Dim::_3D> v_T { ZERO }, v_XYZ { ZERO };
-          energy_dist_1(x_Ph, v_T, spidx1);
-          metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd, v_T, v_XYZ);
-          ux1s_1(index + offset1) = v_XYZ[0];
-          ux2s_1(index + offset1) = v_XYZ[1];
-          ux3s_1(index + offset1) = v_XYZ[2];
-          energy_dist_2(x_Ph, v_T, spidx2);
-          metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd, v_T, v_XYZ);
-          ux1s_2(index + offset2) = v_XYZ[0];
-          ux2s_2(index + offset2) = v_XYZ[1];
-          ux3s_2(index + offset2) = v_XYZ[2];
-
-          tags_1(index + offset1) = ParticleTag::alive;
-          tags_2(index + offset2) = ParticleTag::alive;
-          if (M::CoordType == Coord::Cart) {
-            weights_1(index + offset1) = ONE;
-            weights_2(index + offset2) = ONE;
-          } else {
-            const auto wei = metric.sqrt_det_h({ i1_ + HALF }) * inv_V0;
-            weights_1(index + offset1) = wei;
-            weights_2(index + offset2) = wei;
+          vec_t<Dim::_3D> v_XYZ { ZERO };
+          {
+            vec_t<Dim::_3D> v_T { ZERO };
+            energy_dist_1(x_Ph, v_T);
+            metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd, v_T, v_XYZ);
           }
+          inject1(index, { static_cast<int>(i1_) }, { dx1 }, v_XYZ, weight);
+
+          {
+            vec_t<Dim::_3D> v_T { ZERO };
+            energy_dist_2(x_Ph, v_T);
+            metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd, v_T, v_XYZ);
+          }
+          inject2(index, { static_cast<int>(i1_) }, { dx1 }, v_XYZ, weight);
         }
-        random_pool.free_state(rand_gen);
       } else {
         raise::KernelError(HERE, "NonUniformInjector_kernel 1D called for 2D/3D");
       }
@@ -680,58 +721,55 @@ namespace kernel {
           x_Cd_[2] = ZERO;
         }
         metric.template convert<Crd::Cd, Crd::Ph>(x_Cd, x_Ph);
+
         const auto ppc = static_cast<npart_t>(ppc0 * spatial_dist(x_Ph));
         if (ppc == 0) {
           return;
         }
-        auto rand_gen = random_pool.get_state();
+
+        auto weight = ONE;
+        if constexpr (M::CoordType != Coord::Cart) {
+          weight = metric.sqrt_det_h({ i1_ + HALF, i2_ + HALF }) * inv_V0;
+        }
         for (auto p { 0u }; p < ppc; ++p) {
           const auto index = Kokkos::atomic_fetch_add(&idx(), 1);
-          const auto dx1   = Random<prtldx_t>(rand_gen);
-          const auto dx2   = Random<prtldx_t>(rand_gen);
 
-          i1s_1(index + offset1)  = static_cast<int>(i1) - N_GHOSTS;
-          dx1s_1(index + offset1) = dx1;
-          i1s_2(index + offset2)  = static_cast<int>(i1) - N_GHOSTS;
-          dx1s_2(index + offset2) = dx1;
+          auto       rand_gen = random_pool.get_state();
+          const auto dx1      = Random<prtldx_t>(rand_gen);
+          const auto dx2      = Random<prtldx_t>(rand_gen);
+          random_pool.free_state(rand_gen);
 
-          i2s_1(index + offset1)  = static_cast<int>(i2) - N_GHOSTS;
-          dx2s_1(index + offset1) = dx2;
-          i2s_2(index + offset2)  = static_cast<int>(i2) - N_GHOSTS;
-          dx2s_2(index + offset2) = dx2;
-
-          vec_t<Dim::_3D> v_T { ZERO }, v_Cd { ZERO };
-          energy_dist_1(x_Ph, v_T, spidx1);
-          if constexpr (S == SimEngine::SRPIC) {
-            metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd_, v_T, v_Cd);
-          } else if constexpr (S == SimEngine::GRPIC) {
-            metric.template transform<Idx::T, Idx::D>(x_Cd_, v_T, v_Cd);
+          vec_t<Dim::_3D> v_Cd { ZERO };
+          {
+            vec_t<Dim::_3D> v_T { ZERO };
+            energy_dist_1(x_Ph, v_T);
+            if constexpr (S == SimEngine::SRPIC) {
+              metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd_, v_T, v_Cd);
+            } else if constexpr (S == SimEngine::GRPIC) {
+              metric.template transform<Idx::T, Idx::D>(x_Cd_, v_T, v_Cd);
+            }
           }
-          ux1s_1(index + offset1) = v_Cd[0];
-          ux2s_1(index + offset1) = v_Cd[1];
-          ux3s_1(index + offset1) = v_Cd[2];
-          energy_dist_2(x_Ph, v_T, spidx2);
-          if constexpr (S == SimEngine::SRPIC) {
-            metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd_, v_T, v_Cd);
-          } else if constexpr (S == SimEngine::GRPIC) {
-            metric.template transform<Idx::T, Idx::D>(x_Cd_, v_T, v_Cd);
-          }
-          ux1s_2(index + offset2) = v_Cd[0];
-          ux2s_2(index + offset2) = v_Cd[1];
-          ux3s_2(index + offset2) = v_Cd[2];
+          inject1(index,
+                  { static_cast<int>(i1_), static_cast<int>(i2_) },
+                  { dx1, dx2 },
+                  v_Cd,
+                  weight);
 
-          tags_1(index + offset1) = ParticleTag::alive;
-          tags_2(index + offset2) = ParticleTag::alive;
-          if (M::CoordType == Coord::Cart) {
-            weights_1(index + offset1) = ONE;
-            weights_2(index + offset2) = ONE;
-          } else {
-            const auto wei = metric.sqrt_det_h({ i1_ + HALF, i2_ + HALF }) * inv_V0;
-            weights_1(index + offset1) = wei;
-            weights_2(index + offset2) = wei;
+          {
+            vec_t<Dim::_3D> v_T { ZERO };
+            energy_dist_2(x_Ph, v_T);
+            if constexpr (S == SimEngine::SRPIC) {
+              metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd_, v_T, v_Cd);
+            } else if constexpr (S == SimEngine::GRPIC) {
+              metric.template transform<Idx::T, Idx::D>(x_Cd_, v_T, v_Cd);
+            }
           }
+          inject2(index,
+                  { static_cast<int>(i1_), static_cast<int>(i2_) },
+                  { dx1, dx2 },
+                  v_Cd,
+                  weight);
         }
-        random_pool.free_state(rand_gen);
       }
 
       else {
@@ -747,66 +785,59 @@ namespace kernel {
         coord_t<Dim::_3D> x_Cd { i1_ + HALF, i2_ + HALF, i3_ + HALF };
         coord_t<Dim::_3D> x_Ph { ZERO };
         metric.template convert<Crd::Cd, Crd::Ph>(x_Cd, x_Ph);
+
         const auto ppc = static_cast<npart_t>(ppc0 * spatial_dist(x_Ph));
         if (ppc == 0) {
           return;
         }
-        auto rand_gen = random_pool.get_state();
+
+        auto weight = ONE;
+        if constexpr (M::CoordType != Coord::Cart) {
+          weight = metric.sqrt_det_h({ i1_ + HALF, i2_ + HALF, i3_ + HALF }) *
+                   inv_V0;
+        }
         for (auto p { 0u }; p < ppc; ++p) {
           const auto index = Kokkos::atomic_fetch_add(&idx(), 1);
-          const auto dx1   = Random<prtldx_t>(rand_gen);
-          const auto dx2   = Random<prtldx_t>(rand_gen);
-          const auto dx3   = Random<prtldx_t>(rand_gen);
 
-          i1s_1(index + offset1)  = static_cast<int>(i1) - N_GHOSTS;
-          dx1s_1(index + offset1) = dx1;
-          i1s_2(index + offset2)  = static_cast<int>(i1) - N_GHOSTS;
-          dx1s_2(index + offset2) = dx1;
+          auto       rand_gen = random_pool.get_state();
+          const auto dx1      = Random<prtldx_t>(rand_gen);
+          const auto dx2      = Random<prtldx_t>(rand_gen);
+          const auto dx3      = Random<prtldx_t>(rand_gen);
+          random_pool.free_state(rand_gen);
 
-          i2s_1(index + offset1)  = static_cast<int>(i2) - N_GHOSTS;
-          dx2s_1(index + offset1) = dx2;
-          i2s_2(index + offset2)  = static_cast<int>(i2) - N_GHOSTS;
-          dx2s_2(index + offset2) = dx2;
-
-          i3s_1(index + offset1)  = static_cast<int>(i3) - N_GHOSTS;
-          dx3s_1(index + offset1) = dx3;
-          i3s_2(index + offset2)  = static_cast<int>(i3) - N_GHOSTS;
-          dx3s_2(index + offset2) = dx3;
-
-          vec_t<Dim::_3D> v_T { ZERO }, v_Cd { ZERO };
-          energy_dist_1(x_Ph, v_T, spidx1);
-          if constexpr (S == SimEngine::SRPIC) {
-            metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd, v_T, v_Cd);
-          } else if constexpr (S == SimEngine::GRPIC) {
-            metric.template transform<Idx::T, Idx::D>(x_Cd, v_T, v_Cd);
+          vec_t<Dim::_3D> v_Cd { ZERO };
+          {
+            vec_t<Dim::_3D> v_T { ZERO };
+            energy_dist_1(x_Ph, v_T);
+            if constexpr (S == SimEngine::SRPIC) {
+              metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd, v_T, v_Cd);
+            } else if constexpr (S == SimEngine::GRPIC) {
+              metric.template transform<Idx::T, Idx::D>(x_Cd, v_T, v_Cd);
+            }
           }
-          ux1s_1(index + offset1) = v_Cd[0];
-          ux2s_1(index + offset1) = v_Cd[1];
-          ux3s_1(index + offset1) = v_Cd[2];
-          energy_dist_2(x_Ph, v_T, spidx2);
-          if constexpr (S == SimEngine::SRPIC) {
-            metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd, v_T, v_Cd);
-          } else if constexpr (S == SimEngine::GRPIC) {
-            metric.template transform<Idx::T, Idx::D>(x_Cd, v_T, v_Cd);
-          }
-          ux1s_2(index + offset2) = v_Cd[0];
-          ux2s_2(index + offset2) = v_Cd[1];
-          ux3s_2(index + offset2) = v_Cd[2];
+          inject1(
+            index,
+            { static_cast<int>(i1_), static_cast<int>(i2_), static_cast<int>(i3_) },
+            { dx1, dx2, dx3 },
+            v_Cd,
+            weight);
 
-          tags_1(index + offset1) = ParticleTag::alive;
-          tags_2(index + offset2) = ParticleTag::alive;
-          if (M::CoordType == Coord::Cart) {
-            weights_1(index + offset1) = ONE;
-            weights_2(index + offset2) = ONE;
-          } else {
-            const auto wei = metric.sqrt_det_h(
-                               { i1_ + HALF, i2_ + HALF, i3_ + HALF }) *
-                             inv_V0;
-            weights_1(index + offset1) = wei;
-            weights_2(index + offset2) = wei;
+          {
+            vec_t<Dim::_3D> v_T { ZERO };
+            energy_dist_2(x_Ph, v_T);
+            if constexpr (S == SimEngine::SRPIC) {
+              metric.template transform_xyz<Idx::T, Idx::XYZ>(x_Cd, v_T, v_Cd);
+            } else if constexpr (S == SimEngine::GRPIC) {
+              metric.template transform<Idx::T, Idx::D>(x_Cd, v_T, v_Cd);
+            }
           }
+          inject2(
+            index,
+            { static_cast<int>(i1_), static_cast<int>(i2_), static_cast<int>(i3_) },
+            { dx1, dx2, dx3 },
+            v_Cd,
+            weight);
         }
-        random_pool.free_state(rand_gen);
       } else {
         raise::KernelError(HERE, "NonUniformInjector_kernel 3D called for 1D/2D");
       }

--- a/src/kernels/prtls_to_phys.hpp
+++ b/src/kernels/prtls_to_phys.hpp
@@ -118,7 +118,7 @@ namespace kernel {
     }
 
     Inline void operator()(index_t p) const {
-      if constexpr (!T) { // no tracking enabled
+      if constexpr (not T) { // no tracking enabled
         bufferX(p * stride, p);
         bufferU(p * stride, p);
         buff_wei(p) = weight(p * stride);
@@ -131,7 +131,7 @@ namespace kernel {
       }
     }
 
-    Inline void bufferX(index_t& p_from, index_t& p_to) const {
+    Inline void bufferX(const index_t& p_from, const index_t& p_to) const {
       if constexpr ((D == Dim::_1D) || (D == Dim::_2D) || (D == Dim::_3D)) {
         buff_x1(p_to) = metric.template convert<1, Crd::Cd, Crd::Ph>(
           static_cast<real_t>(i1(p_from)) + static_cast<real_t>(dx1(p_from)));
@@ -148,7 +148,7 @@ namespace kernel {
       }
     }
 
-    Inline void bufferU(index_t& p_from, index_t& p_to) const {
+    Inline void bufferU(const index_t& p_from, const index_t& p_to) const {
       vec_t<Dim::_3D> u_Phys { ZERO };
       if constexpr (D == Dim::_1D) {
         if constexpr (M::CoordType == Coord::Cart) {
@@ -206,16 +206,12 @@ namespace kernel {
       buff_ux3(p_to) = u_Phys[2];
     }
 
-    Inline void bufferPlds(index_t& p_from, index_t& p_to) const {
-      if (buff_pldr.extent(0) > 0) {
-        for (auto pr { 0u }; pr < buff_pldr.extent(1); ++pr) {
-          buff_pldr(p_to, pr) = pld_r(p_from, pr);
-        }
+    Inline void bufferPlds(const index_t& p_from, const index_t& p_to) const {
+      for (auto pr { 0u }; pr < buff_pldr.extent(1); ++pr) {
+        buff_pldr(p_to, pr) = pld_r(p_from, pr);
       }
-      if (buff_pldi.extent(0) > 0) {
-        for (auto pi { 0u }; pi < buff_pldi.extent(1); ++pi) {
-          buff_pldi(p_to, pi) = pld_i(p_from, pi);
-        }
+      for (auto pi { 0u }; pi < buff_pldi.extent(1); ++pi) {
+        buff_pldi(p_to, pi) = pld_i(p_from, pi);
       }
     }
   };

--- a/src/kernels/prtls_to_phys.hpp
+++ b/src/kernels/prtls_to_phys.hpp
@@ -142,8 +142,7 @@ namespace kernel {
       }
       if constexpr ((D == Dim::_2D) && (M::CoordType != Coord::Cart)) {
         buff_x3(p_to) = phi(p_from);
-      }
-      if constexpr (D == Dim::_3D) {
+      } else if constexpr (D == Dim::_3D) {
         buff_x3(p_to) = metric.template convert<3, Crd::Cd, Crd::Ph>(
           static_cast<real_t>(i3(p_from)) + static_cast<real_t>(dx3(p_from)));
       }


### PR DESCRIPTION
# Breaking changes

- Particle injector archetypes are now greatly simplified:

### Uniform injector

```c++
const auto energy_dist_1 = ...;
const auto energy_dist_2 = ...;

InjectUniform<S, M, decltype(energy_dist_1), decltype(energy_dist_2)>(
  params, 
  domain,
  { 1, 2 },
  { energy_dist_1, energy_dist_2 },
  total_number_density
)
```

### Nonuniform injector

```c++
const auto energy_dist_1 = ...;
const auto energy_dist_2 = ...;
const auto spatial_dist = ...;

InjectNonUniform<S, M, decltype(energy_dist_1), decltype(energy_dist_2), decltype(spatial_dist)>(
  params, 
  domain,
  { 1, 2 },
  { energy_dist_1, energy_dist_2 },
  spatial_dist,
  max_number_density
)
```

> You may pass the same `energy_dist` instance for both species.

- `.info`, `.log`, `.err` files are now written in the same directory as the output
- there is an additional `.out` file which accumulates the `stdout`