### PR TITLE
Fixed the random number generator issue on large # of GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(PROJECT_NAME entity)
 
 project(
   ${PROJECT_NAME}
-  VERSION 1.3.2
+  VERSION 1.3.3
   LANGUAGES CXX C)
 add_compile_options("-D ENTITY_VERSION=\"${PROJECT_VERSION}\"")
 set(hash_cmd "git diff --quiet src/ && echo $(git rev-parse HEAD) ")

--- a/pgens/accretion/pgen.hpp
+++ b/pgens/accretion/pgen.hpp
@@ -231,7 +231,7 @@ namespace user {
 
     inline void InitPrtls(Domain<S, M>& local_domain) {
       const auto energy_dist  = arch::Maxwellian<S, M>(local_domain.mesh.metric,
-                                                      local_domain.random_pool,
+                                                      local_domain.random_pool(),
                                                       temperature);
       const auto spatial_dist = PointDistribution<S, M>(xi_min,
                                                         xi_max,
@@ -252,7 +252,7 @@ namespace user {
 
     void CustomPostStep(std::size_t, long double time, Domain<S, M>& local_domain) {
       const auto energy_dist  = arch::Maxwellian<S, M>(local_domain.mesh.metric,
-                                                      local_domain.random_pool,
+                                                      local_domain.random_pool(),
                                                       temperature);
       const auto spatial_dist = PointDistribution<S, M>(xi_min,
                                                         xi_max,

--- a/pgens/reconnection/pgen.hpp
+++ b/pgens/reconnection/pgen.hpp
@@ -212,7 +212,7 @@ namespace user {
 
       // current layer
       auto       edist_cs = arch::Maxwellian<S, M>(local_domain.mesh.metric,
-                                             local_domain.random_pool,
+                                             local_domain.random_pool(),
                                              cs_temperature,
                                                    { ZERO, ZERO, cs_drift_u });
       const auto sdist_cs = CurrentLayer<S, M>(local_domain.mesh.metric,
@@ -239,7 +239,7 @@ namespace user {
       }
 
       const auto energy_dist = arch::Maxwellian<S, M>(domain.mesh.metric,
-                                                      domain.random_pool,
+                                                      domain.random_pool(),
                                                       bg_temperature);
 
       const auto dx = domain.mesh.metric.template sqrt_h_<1, 1>({});

--- a/pgens/turbulence/pgen.hpp
+++ b/pgens/turbulence/pgen.hpp
@@ -398,7 +398,7 @@ namespace user {
 
       // particle escape (resample velocities)
       const auto energy_dist = arch::Maxwellian<S, M>(domain.mesh.metric,
-                                                      domain.random_pool,
+                                                      domain.random_pool(),
                                                       temperature);
       for (const auto& sp : { 0, 1 }) {
         if (domain.species[sp].npld_r() > 1) {

--- a/src/archetypes/particle_injector.h
+++ b/src/archetypes/particle_injector.h
@@ -254,7 +254,7 @@ namespace arch {
                              energy_dists.first,
                              energy_dists.second,
                              ONE / params.template get<real_t>("scales.V0"),
-                             domain.random_pool));
+                             domain.random_pool()));
       domain.species[species.first - 1].set_npart(
         domain.species[species.first - 1].npart() + nparticles);
       domain.species[species.second - 1].set_npart(
@@ -372,7 +372,7 @@ namespace arch {
         energy_dists.second,
         spatial_dist,
         ONE / params.template get<real_t>("scales.V0"),
-        domain.random_pool);
+        domain.random_pool());
       Kokkos::parallel_for("InjectNonUniformNumberDensity",
                            cell_range,
                            injector_kernel);

--- a/src/archetypes/utils.h
+++ b/src/archetypes/utils.h
@@ -53,11 +53,11 @@ namespace arch {
     const auto temperature_2 = temperatures.second / mass_2;
 
     const auto maxwellian_1 = arch::Maxwellian<S, M>(domain.mesh.metric,
-                                                     domain.random_pool,
+                                                     domain.random_pool(),
                                                      temperature_1,
                                                      drift_four_vels.first);
     const auto maxwellian_2 = arch::Maxwellian<S, M>(domain.mesh.metric,
-                                                     domain.random_pool,
+                                                     domain.random_pool(),
                                                      temperature_2,
                                                      drift_four_vels.second);
 

--- a/src/engines/srpic.hpp
+++ b/src/engines/srpic.hpp
@@ -1291,7 +1291,7 @@ namespace ntt {
       }
 
       const auto maxwellian = arch::Maxwellian<S, M> { domain.mesh.metric,
-                                                       domain.random_pool,
+                                                       domain.random_pool(),
                                                        temp };
 
       if (dim == in::x1) {

--- a/src/framework/domain/domain.h
+++ b/src/framework/domain/domain.h
@@ -53,6 +53,7 @@
 
 #include <iomanip>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -65,7 +66,6 @@ namespace ntt {
     Mesh<M>                                 mesh;
     Fields<D, S>                            fields;
     std::vector<Particles<D, M::CoordType>> species;
-    random_number_pool_t                    random_pool;
 
     /**
      * @brief constructor for "empty" allocation of non-local domain placeholders
@@ -81,7 +81,6 @@ namespace ntt {
       : mesh { ncells, extent, metric_params }
       , fields {}
       , species {}
-      , random_pool { constant::RandomSeed }
       , m_index { index }
       , m_offset_ndomains { offset_ndomains }
       , m_offset_ncells { offset_ncells } {}
@@ -96,7 +95,8 @@ namespace ntt {
       : mesh { ncells, extent, metric_params }
       , fields { ncells }
       , species { species_params.begin(), species_params.end() }
-      , random_pool { constant::RandomSeed + static_cast<std::uint64_t>(index) }
+      , m_random_number_pool { constant::RandomSeed +
+                               static_cast<std::uint64_t>(index) }
       , m_index { index }
       , m_offset_ndomains { offset_ndomains }
       , m_offset_ncells { offset_ncells } {}
@@ -145,6 +145,14 @@ namespace ntt {
       return fields.memory_footprint() == 0 and sp_footprint == 0;
     }
 
+    [[nodiscard]]
+    auto random_pool() -> random_number_pool_t& {
+      raise::ErrorIf(not m_random_number_pool.has_value(),
+                     "random_pool() called on a placeholder domain",
+                     HERE);
+      return m_random_number_pool.value();
+    }
+
     /* setters -------------------------------------------------------------- */
     auto set_neighbor_idx(const dir::direction_t<D>& dir, unsigned int idx) -> void {
       m_neighbor_idx[dir] = idx;
@@ -161,6 +169,9 @@ namespace ntt {
     dir::map_t<D, unsigned int> m_neighbor_idx;
     // MPI rank of the domain (used only when MPI enabled)
     int                         m_mpi_rank;
+
+    // random number pool for the domain
+    std::optional<random_number_pool_t> m_random_number_pool;
   };
 
   template <SimEngine::type S, class M>

--- a/src/framework/domain/domain.h
+++ b/src/framework/domain/domain.h
@@ -95,11 +95,11 @@ namespace ntt {
       : mesh { ncells, extent, metric_params }
       , fields { ncells }
       , species { species_params.begin(), species_params.end() }
-      , m_random_number_pool { constant::RandomSeed +
-                               static_cast<std::uint64_t>(index) }
       , m_index { index }
       , m_offset_ndomains { offset_ndomains }
-      , m_offset_ncells { offset_ncells } {}
+      , m_offset_ncells { offset_ncells }
+      , m_random_number_pool { constant::RandomSeed +
+                               static_cast<std::uint64_t>(index) } {}
 
 #if defined(MPI_ENABLED)
     [[nodiscard]]


### PR DESCRIPTION
The issue was caused by the unnecessary allocation of `random_number_pool_t` objects on all `Domain`-s of the `Metadomain`, including the placeholder ones which did not belong to the given rank. The solution is to use `std::optional` wrapper for the object, and only get it by `.value()` when it `.has_value()` is satisfied.

## API changes
- now the random pool is accessed via `random_pool()` method of the domain, instead of directly getting the `random_pool` object. when trying to access this from the placeholder domain, will throw an error.