### PR TITLE
Custom (user-defined) emission policy

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -108,6 +108,10 @@ IncludeCategories:
     Priority: 4
   - Regex: '^"checkpoint\/.*\.h"'
     Priority: 4
+  - Regex: '^"kernels\/.*\.hpp"'
+    Priority: 4
+  - Regex: '^"kernels\/.*\.h"'
+    Priority: 4
   - Regex: '^"output\/.*\.h"'
     Priority: 4
   - Regex: '^"archetypes\/.*\.h"'

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/cpuarch.yml
+++ b/.github/workflows/cpuarch.yml
@@ -63,8 +63,10 @@ jobs:
           cmake --version
       - name: Install OpenMPI 5
         run: |
-          sudo apt-get install -y libopenmpi-dev openmpi-bin
-          mpirun --version
+          if [ "${{ matrix.mpi }}" = "ON" ]; then
+            sudo apt-get install -y libopenmpi-dev openmpi-bin
+            mpirun --version
+          fi
       - name: Configure
         run: |
           if [ "${{ matrix.mpi }}" = "ON" ]; then
@@ -87,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pgen: [streaming, turbulence, reconnection, shock, magnetosphere, accretion, wald]
+        pgen: [streaming, turbulence, reconnection, shock, magnetosphere, accretion, wald, examples/custom_emission]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ venv/
 *.mov
 *.mp4
 !pgens/**/*.png
+!pgens/**/*.mp4
 
 # Accidental files
 *.xc

--- a/pgens/examples/README.md
+++ b/pgens/examples/README.md
@@ -3,3 +3,5 @@
 Problem generations in this directory are just examples demonstrating how to use some of the features of the Entity.
 
 - `custom_emission`: simple example where two particles are initialized on gyrating trajectories probabilistically emitting photons while the total energy is conserved.
+
+  https://github.com/user-attachments/assets/6c5c399a-bbab-4b93-be5f-35fed1959fcc

--- a/pgens/examples/README.md
+++ b/pgens/examples/README.md
@@ -1,0 +1,5 @@
+# Examples
+
+Problem generations in this directory are just examples demonstrating how to use some of the features of the Entity.
+
+- `custom_emission`: simple example where two particles are initialized on gyrating trajectories probabilistically emitting photons while the total energy is conserved.

--- a/pgens/examples/custom_emission/custom_emission.mp4
+++ b/pgens/examples/custom_emission/custom_emission.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:320b85667465db5f2537a67f95462aeca96caa6cff2f80ae3fb57abfa09c95d4
+size 2896072

--- a/pgens/examples/custom_emission/custom_emission.py
+++ b/pgens/examples/custom_emission/custom_emission.py
@@ -1,0 +1,51 @@
+import nt2
+import matplotlib.pyplot as plt
+import numpy as np
+
+plt.rcParams["text.usetex"] = True
+
+data = nt2.Data("custom_emission")
+
+
+def plot(t, data):
+    fig = plt.figure(figsize=(8, 4), dpi=150)
+    ax1 = fig.add_subplot(121)
+    prtls = data.particles.sel(t=slice(t - 0.5, t)).load()
+    prtls.plot.scatter(
+        ax=ax1,
+        x="x",
+        y="y",
+        color=["r" if sp == 1 else "b" for sp in prtls["sp"]],
+        ec=None,
+        alpha=(1 - (t - prtls["t"]) / 0.5) ** 2,
+        s=(1 - (t - prtls["t"]) / 0.5) * 5,
+    )
+    ax1.set(xlabel=r"$x$", ylabel=r"$y$", xlim=(-1, 1), ylim=(-1, 1), aspect=1)
+
+    ax2 = fig.add_subplot(122)
+    prtls1 = data.particles.sel(sp=1, t=slice(None, t)).load()
+    prtls2 = data.particles.sel(sp=2, t=slice(None, t)).load()
+    e1 = (
+        prtls1.assign(
+            e=np.sqrt(1 + prtls1["ux"] ** 2 + prtls1["uy"] ** 2 + prtls1["uz"] ** 2)
+        )
+        .groupby("t", as_index=False)["e"]
+        .sum()
+    )
+    e2 = (
+        prtls2.assign(
+            e=np.sqrt(prtls2["ux"] ** 2 + prtls2["uy"] ** 2 + prtls2["uz"] ** 2)
+        )
+        .groupby("t", as_index=False)["e"]
+        .sum()
+    )
+    e = e1.merge(e2, on="t", how="outer", suffixes=("_1", "_2")).fillna(0)
+    ax2.plot(e.t, e.e_1, label="emitters", c="r")
+    ax2.plot(e.t, e.e_2, label="emitted", c="b")
+    ax2.plot(e.t, e.e_1 + e.e_2, label="total", c="k")
+    ax2.set(xlabel=r"$t$", ylabel=r"total energy", xlim=(0, 5), ylim=(0, 3))
+    ax2.axvline(t, color="gray", ls="--")
+    ax2.legend(loc="center left")
+
+
+data.makeMovie(plot, framerate=30)

--- a/pgens/examples/custom_emission/custom_emission.toml
+++ b/pgens/examples/custom_emission/custom_emission.toml
@@ -1,0 +1,68 @@
+[simulation]
+  name    = "custom_emission"
+  engine  = "srpic"
+  runtime = 5.0
+
+[grid]
+  resolution = [64, 64]
+  extent     = [[-1.0, 1.0], [-1.0, 1.0]]
+
+  [grid.metric]
+    metric = "minkowski"
+
+  [grid.boundaries]
+    fields    = [["PERIODIC"], ["PERIODIC"]]
+    particles = [["PERIODIC"], ["PERIODIC"]]
+
+[scales]
+  larmor0    = 0.25
+  skindepth0 = 1.0
+
+[algorithms]
+
+  [algorithms.deposit]
+    enable = false
+
+  [algorithms.timestep]
+    CFL = 0.5
+
+[particles]
+  ppc0 = 1.0
+
+  [[particles.species]]
+    label    = "p"
+    mass     = 1.0
+    charge   = 1.0
+    maxnpart = 1e2
+    emission = "custom"
+
+  [[particles.species]]
+    label    = "ph"
+    mass     = 0.0
+    charge   = 0.0
+    maxnpart = 1e4
+
+[setup]
+  x1_arr               = [0.0, 0.0]
+  x2_arr               = [0.0, 0.0]
+  x3_arr               = [0.0, 0.0]
+  ux1_arr              = [0.0, 0.0]
+  ux2_arr              = [1.0, -1.0]
+  ux3_arr              = [0.0, 0.0]
+  emission_probability = 0.05
+
+[output]
+  interval = 1
+
+  [output.fields]
+    quantities = ["N_1", "N_2", "B"]
+
+  [output.particles]
+    enable = true
+    stride = 1
+
+  [output.spectra]
+    enable = false
+
+[checkpoint]
+  keep = 0

--- a/pgens/examples/custom_emission/pgen.hpp
+++ b/pgens/examples/custom_emission/pgen.hpp
@@ -24,7 +24,7 @@ namespace user {
 
   template <Dimension D>
   struct InitFields {
-    Inline auto bx3(const coord_t<D>& x_Ph) const -> real_t {
+    Inline auto bx3(const coord_t<D>&) const -> real_t {
       return ONE;
     }
   };
@@ -32,7 +32,7 @@ namespace user {
   template <class M>
   struct RandomEmission {
     struct Payload {
-      real_t photon_energy;
+      real_t photon_energy { ZERO };
     };
 
     random_number_pool_t random_pool;

--- a/pgens/examples/custom_emission/pgen.hpp
+++ b/pgens/examples/custom_emission/pgen.hpp
@@ -155,10 +155,6 @@ namespace user {
       Kokkos::deep_copy(inj_idx_h, inj_idx);
       return { inj_idx_h() };
     }
-
-    static_assert(
-      kernel::traits::emission::IsValid<RandomEmission<M>, M>,
-      "RandomEmission does not satisfy the requirements of an emission policy");
   };
 
   template <SimEngine::type S, class M>
@@ -187,10 +183,13 @@ namespace user {
       : arch::ProblemGenerator<S, M> { p }
       , metadomain { metadomain }
       , emission_probability { params.template get<real_t>(
-          "setup.emission_probability") } {}
+          "setup.emission_probability") } {
+      static_assert(kernel::traits::emission::IsValid<RandomEmission<M>, M>, "RandomEmission does not satisfy the requirements of an emission policy");
+    }
 
-    inline auto EmissionPolicy(simtime_t, spidx_t, Domain<S, M>& domain) const
-      -> RandomEmission<M> {
+    inline auto EmissionPolicy(simtime_t,
+                               spidx_t,
+                               Domain<S, M>& domain) const -> RandomEmission<M> {
       return RandomEmission<M> {
         domain.random_pool(),      emission_probability,
         domain.species[1].npart(), domain.species[1].i1,

--- a/pgens/examples/custom_emission/pgen.hpp
+++ b/pgens/examples/custom_emission/pgen.hpp
@@ -1,0 +1,239 @@
+#ifndef PROBLEM_GENERATOR_H
+#define PROBLEM_GENERATOR_H
+
+#include "enums.h"
+#include "global.h"
+
+#include "arch/kokkos_aliases.h"
+
+#include "archetypes/particle_injector.h"
+#include "archetypes/problem_generator.h"
+#include "archetypes/traits.h"
+#include "framework/domain/metadomain.h"
+#include "kernels/emission/traits.h"
+#include "kernels/injectors.hpp"
+
+#include <Kokkos_Pair.hpp>
+
+#include <vector>
+
+namespace user {
+  using namespace ntt;
+
+  template <Dimension D>
+  struct InitFields {
+    Inline auto bx3(const coord_t<D>& x_Ph) const -> real_t {
+      return ONE;
+    }
+  };
+
+  template <class M>
+  struct RandomEmission {
+    struct Payload {
+      real_t photon_energy;
+    };
+
+    random_number_pool_t random_pool;
+    const real_t         probability;
+
+    array_t<npart_t> inj_idx { "inj_idx" };
+    const npart_t    inj_offset;
+
+    array_t<int*>      inj_i1, inj_i2, inj_i3;
+    array_t<prtldx_t*> inj_dx1, inj_dx2, inj_dx3;
+    array_t<real_t*>   inj_ux1, inj_ux2, inj_ux3;
+    array_t<real_t*>   inj_phi;
+    array_t<real_t*>   inj_weight;
+    array_t<short*>    inj_tag;
+    array_t<npart_t**> inj_pld_i;
+
+    RandomEmission(random_number_pool_t& random_pool,
+                   real_t                probability,
+                   npart_t               inj_offset,
+                   array_t<int*>&        inj_i1,
+                   array_t<int*>&        inj_i2,
+                   array_t<int*>&        inj_i3,
+                   array_t<prtldx_t*>&   inj_dx1,
+                   array_t<prtldx_t*>&   inj_dx2,
+                   array_t<prtldx_t*>&   inj_dx3,
+                   array_t<real_t*>&     inj_ux1,
+                   array_t<real_t*>&     inj_ux2,
+                   array_t<real_t*>&     inj_ux3,
+                   array_t<real_t*>&     inj_phi,
+                   array_t<real_t*>&     inj_weight,
+                   array_t<short*>&      inj_tag,
+                   array_t<npart_t**>&   inj_pld_i)
+      : random_pool { random_pool }
+      , probability { probability }
+      , inj_offset { inj_offset }
+      , inj_i1 { inj_i1 }
+      , inj_i2 { inj_i2 }
+      , inj_i3 { inj_i3 }
+      , inj_dx1 { inj_dx1 }
+      , inj_dx2 { inj_dx2 }
+      , inj_dx3 { inj_dx3 }
+      , inj_ux1 { inj_ux1 }
+      , inj_ux2 { inj_ux2 }
+      , inj_ux3 { inj_ux3 }
+      , inj_phi { inj_phi }
+      , inj_weight { inj_weight }
+      , inj_tag { inj_tag }
+      , inj_pld_i { inj_pld_i } {}
+
+    Inline auto shouldEmit(const coord_t<M::PrtlDim>&,
+                           const coord_t<M::PrtlDim>&,
+                           const vec_t<Dim::_3D>& u_Ph,
+                           const vec_t<Dim::_3D>&,
+                           const vec_t<Dim::_3D>&,
+                           vec_t<Dim::_3D>& delta_u_Ph,
+                           Payload& payload) const -> Kokkos::pair<bool, bool> {
+      auto       generator = random_pool.get_state();
+      const auto rnd       = Random<real_t>(generator);
+      random_pool.free_state(generator);
+      if (rnd < probability) {
+        delta_u_Ph[0] = -0.1 * u_Ph[0];
+        delta_u_Ph[1] = -0.1 * u_Ph[1];
+        delta_u_Ph[2] = -0.1 * u_Ph[2];
+
+        const auto uSqr          = NORM_SQR(u_Ph[0], u_Ph[1], u_Ph[2]);
+        const auto gammaSqr      = ONE + uSqr;
+        const auto delta_uSqr    = NORM_SQR(delta_u_Ph[0],
+                                         delta_u_Ph[1],
+                                         delta_u_Ph[2]);
+        const auto u_dot_delta_u = DOT(u_Ph[0],
+                                       u_Ph[1],
+                                       u_Ph[2],
+                                       delta_u_Ph[0],
+                                       delta_u_Ph[1],
+                                       delta_u_Ph[2]);
+        payload.photon_energy    = math::sqrt(gammaSqr) *
+                                (math::sqrt(ONE + delta_uSqr / gammaSqr +
+                                            TWO * u_dot_delta_u / gammaSqr) -
+                                 ONE);
+        return { true, true };
+      }
+      return { false, false };
+    }
+
+    Inline auto emit(const tuple_t<int, M::Dim>&      xi_Cd,
+                     const tuple_t<prtldx_t, M::Dim>& dxi_Cd,
+                     const vec_t<Dim::_3D>&           direction,
+                     real_t,
+                     real_t,
+                     const Payload& payload) const -> void {
+      const auto inj_index = Kokkos::atomic_fetch_add(&inj_idx(), 1);
+      kernel::InjectParticle<M::Dim, M::CoordType, false>(
+        inj_offset + inj_index,
+        inj_i1,
+        inj_i2,
+        inj_i3,
+        inj_dx1,
+        inj_dx2,
+        inj_dx3,
+        inj_ux1,
+        inj_ux2,
+        inj_ux3,
+        inj_phi,
+        inj_weight,
+        inj_tag,
+        inj_pld_i,
+        xi_Cd,
+        dxi_Cd,
+        { payload.photon_energy * direction[0],
+          payload.photon_energy * direction[1],
+          payload.photon_energy * direction[2] });
+    }
+
+    auto emitted_species_indices() const -> std::vector<spidx_t> {
+      return { 2u };
+    }
+
+    auto numbers_injected() const -> std::vector<npart_t> {
+      auto inj_idx_h = Kokkos::create_mirror_view(inj_idx);
+      Kokkos::deep_copy(inj_idx_h, inj_idx);
+      return { inj_idx_h() };
+    }
+
+    static_assert(
+      kernel::traits::emission::IsValid<RandomEmission<M>, M>,
+      "RandomEmission does not satisfy the requirements of an emission policy");
+  };
+
+  template <SimEngine::type S, class M>
+  struct PGen : public arch::ProblemGenerator<S, M> {
+    static constexpr auto engines {
+      arch::traits::pgen::compatible_with<SimEngine::SRPIC>::value
+    };
+    static constexpr auto metrics {
+      arch::traits::pgen::compatible_with<Metric::Minkowski>::value
+    };
+    static constexpr auto dimensions {
+      arch::traits::pgen::compatible_with<Dim::_1D, Dim::_2D, Dim::_3D>::value
+    };
+
+    using arch::ProblemGenerator<S, M>::D;
+    using arch::ProblemGenerator<S, M>::C;
+    using arch::ProblemGenerator<S, M>::params;
+
+    const Metadomain<S, M>& metadomain;
+
+    const real_t emission_probability;
+
+    InitFields<D> init_flds {};
+
+    inline PGen(const SimulationParams& p, const Metadomain<S, M>& metadomain)
+      : arch::ProblemGenerator<S, M> { p }
+      , metadomain { metadomain }
+      , emission_probability { params.template get<real_t>(
+          "setup.emission_probability") } {}
+
+    inline auto EmissionPolicy(simtime_t, spidx_t, Domain<S, M>& domain) const
+      -> RandomEmission<M> {
+      return RandomEmission<M> {
+        domain.random_pool(),      emission_probability,
+        domain.species[1].npart(), domain.species[1].i1,
+        domain.species[1].i2,      domain.species[1].i3,
+        domain.species[1].dx1,     domain.species[1].dx2,
+        domain.species[1].dx3,     domain.species[1].ux1,
+        domain.species[1].ux2,     domain.species[1].ux3,
+        domain.species[1].phi,     domain.species[1].weight,
+        domain.species[1].tag,     domain.species[1].pld_i
+      };
+    }
+
+    inline void InitPrtls(Domain<S, M>& domain) {
+      const auto empty  = std::vector<real_t> {};
+      const auto x1_arr = params.template get<std::vector<real_t>>(
+        "setup.x1_arr",
+        empty);
+      const auto x2_arr = params.template get<std::vector<real_t>>(
+        "setup.x2_arr",
+        empty);
+      const auto x3_arr = params.template get<std::vector<real_t>>(
+        "setup.x3_arr",
+        empty);
+      const auto ux1_arr = params.template get<std::vector<real_t>>(
+        "setup.ux1_arr",
+        empty);
+      const auto ux2_arr = params.template get<std::vector<real_t>>(
+        "setup.ux2_arr",
+        empty);
+      const auto ux3_arr = params.template get<std::vector<real_t>>(
+        "setup.ux3_arr",
+        empty);
+
+      std::map<std::string, std::vector<real_t>> data_arr {
+        {  "x1",  x1_arr },
+        {  "x2",  x2_arr },
+        {  "x3",  x3_arr },
+        { "ux1", ux1_arr },
+        { "ux2", ux2_arr },
+        { "ux3", ux3_arr }
+      };
+      arch::InjectGlobally<S, M>(metadomain, domain, 1u, data_arr);
+    }
+  };
+
+} // namespace user
+
+#endif

--- a/pgens/examples/custom_emission/pgen.hpp
+++ b/pgens/examples/custom_emission/pgen.hpp
@@ -15,6 +15,8 @@
 
 #include <Kokkos_Pair.hpp>
 
+#include <map>
+#include <string>
 #include <vector>
 
 namespace user {

--- a/pgens/reconnection/pgen.hpp
+++ b/pgens/reconnection/pgen.hpp
@@ -14,7 +14,6 @@
 #include "archetypes/traits.h"
 #include "archetypes/utils.h"
 #include "framework/domain/metadomain.h"
-
 #include "kernels/particle_moments.hpp"
 
 namespace user {

--- a/src/archetypes/energy_dist.h
+++ b/src/archetypes/energy_dist.h
@@ -250,7 +250,7 @@ namespace arch {
       }
     }
 
-    Inline void operator()(const coord_t<M::Dim>& x_Code, vec_t<Dim::_3D>& v) const {
+    Inline void operator()(const coord_t<M::Dim>&, vec_t<Dim::_3D>& v) const {
       if (cmp::AlmostZero(temperature)) {
         v[0] = ZERO;
         v[1] = ZERO;

--- a/src/archetypes/field_setter.h
+++ b/src/archetypes/field_setter.h
@@ -36,23 +36,23 @@ namespace arch {
 
   template <class I, SimEngine::type S, class M>
     requires metric::traits::HasD<M> &&
-             ((S == SimEngine::SRPIC && metric::traits::HasConvert<M> &&
+             (((S == SimEngine::SRPIC) && metric::traits::HasConvert<M> &&
                metric::traits::HasTransform_i<M>) ||
-              (S == SimEngine::GRPIC && metric::traits::HasConvert_i<M>)) &&
-             (S == SimEngine::SRPIC &&
-                (::traits::fieldsetter::HasEx1<I, M::Dim> ||
-                 ::traits::fieldsetter::HasEx2<I, M::Dim> ||
-                 ::traits::fieldsetter::HasEx3<I, M::Dim> ||
-                 ::traits::fieldsetter::HasBx1<I, M::Dim> ||
-                 ::traits::fieldsetter::HasBx2<I, M::Dim> ||
-                 ::traits::fieldsetter::HasBx3<I, M::Dim>) ||
-              (S == SimEngine::GRPIC &&
-                 (::traits::fieldsetter::HasDx1<I, M::Dim> &&
-                  ::traits::fieldsetter::HasDx2<I, M::Dim> &&
-                  ::traits::fieldsetter::HasDx3<I, M::Dim>) ||
-               (::traits::fieldsetter::HasBx1<I, M::Dim> &&
-                ::traits::fieldsetter::HasBx2<I, M::Dim> &&
-                ::traits::fieldsetter::HasBx3<I, M::Dim>)))
+              ((S == SimEngine::GRPIC) && metric::traits::HasConvert_i<M>)) &&
+             (((S == SimEngine::SRPIC) &&
+               (::traits::fieldsetter::HasEx1<I, M::Dim> ||
+                ::traits::fieldsetter::HasEx2<I, M::Dim> ||
+                ::traits::fieldsetter::HasEx3<I, M::Dim> ||
+                ::traits::fieldsetter::HasBx1<I, M::Dim> ||
+                ::traits::fieldsetter::HasBx2<I, M::Dim> ||
+                ::traits::fieldsetter::HasBx3<I, M::Dim>)) ||
+              ((S == SimEngine::GRPIC) &&
+               ((::traits::fieldsetter::HasDx1<I, M::Dim> &&
+                 ::traits::fieldsetter::HasDx2<I, M::Dim> &&
+                 ::traits::fieldsetter::HasDx3<I, M::Dim>) ||
+                (::traits::fieldsetter::HasBx1<I, M::Dim> &&
+                 ::traits::fieldsetter::HasBx2<I, M::Dim> &&
+                 ::traits::fieldsetter::HasBx3<I, M::Dim>))))
   class SetEMFields_kernel {
     static constexpr Dimension D = M::Dim;
 

--- a/src/archetypes/particle_injector.h
+++ b/src/archetypes/particle_injector.h
@@ -26,7 +26,6 @@
 
 #include "framework/domain/domain.h"
 #include "framework/domain/metadomain.h"
-
 #include "kernels/injectors.hpp"
 
 #include <Kokkos_Core.hpp>

--- a/src/archetypes/traits.h
+++ b/src/archetypes/traits.h
@@ -30,6 +30,8 @@
 
 #include "arch/kokkos_aliases.h"
 
+#include "framework/parameters/parameters.h"
+
 namespace arch {
   namespace traits {
 
@@ -76,6 +78,15 @@ namespace arch {
 
       template <class PG>
       concept HasInitFlds = requires(const PG& pgen) { pgen.init_flds; };
+
+      template <class PG, class M, class D>
+      concept HasEmissionPolicy = requires(const PG& pgen,
+                                           simtime_t time,
+                                           spidx_t   sp,
+                                           const D&  domain,
+                                           const ntt::SimulationParams& params) {
+        pgen.EmissionPolicy(time, sp, domain, params);
+      };
 
       template <class PG, class D>
       concept HasInitPrtls = requires(PG& pgen, D& domain) {

--- a/src/archetypes/traits.h
+++ b/src/archetypes/traits.h
@@ -30,8 +30,6 @@
 
 #include "arch/kokkos_aliases.h"
 
-#include "framework/parameters/parameters.h"
-
 namespace arch {
   namespace traits {
 
@@ -83,9 +81,8 @@ namespace arch {
       concept HasEmissionPolicy = requires(const PG& pgen,
                                            simtime_t time,
                                            spidx_t   sp,
-                                           const D&  domain,
-                                           const ntt::SimulationParams& params) {
-        pgen.EmissionPolicy(time, sp, domain, params);
+                                           D&        domain) {
+        pgen.EmissionPolicy(time, sp, domain);
       };
 
       template <class PG, class D>

--- a/src/engines/grpic.hpp
+++ b/src/engines/grpic.hpp
@@ -22,8 +22,6 @@
 
 #include "framework/domain/domain.h"
 #include "framework/parameters/parameters.h"
-
-#include "engines/engine.hpp"
 #include "kernels/ampere_gr.hpp"
 #include "kernels/aux_fields_gr.hpp"
 #include "kernels/currents_deposit.hpp"
@@ -31,6 +29,8 @@
 #include "kernels/faraday_gr.hpp"
 #include "kernels/fields_bcs.hpp"
 #include "kernels/particle_pusher_gr.hpp"
+
+#include "engines/engine.hpp"
 #include "pgen.hpp"
 
 #include <Kokkos_Core.hpp>

--- a/src/engines/srpic/currents.h
+++ b/src/engines/srpic/currents.h
@@ -13,7 +13,6 @@
 #include "engines/srpic/utils.h"
 #include "framework/domain/domain.h"
 #include "framework/domain/metadomain.h"
-
 #include "kernels/currents_deposit.hpp"
 #include "kernels/digital_filter.hpp"
 

--- a/src/engines/srpic/fields_bcs.h
+++ b/src/engines/srpic/fields_bcs.h
@@ -13,7 +13,6 @@
 #include "engines/srpic/utils.h"
 #include "framework/domain/domain.h"
 #include "framework/parameters/parameters.h"
-
 #include "kernels/fields_bcs.hpp"
 
 namespace ntt {

--- a/src/engines/srpic/fieldsolvers.h
+++ b/src/engines/srpic/fieldsolvers.h
@@ -12,7 +12,6 @@
 #include "engines/srpic/utils.h"
 #include "framework/domain/domain.h"
 #include "framework/parameters/parameters.h"
-
 #include "kernels/ampere_mink.hpp"
 #include "kernels/ampere_sr.hpp"
 #include "kernels/faraday_mink.hpp"

--- a/src/engines/srpic/particle_pusher.h
+++ b/src/engines/srpic/particle_pusher.h
@@ -19,6 +19,7 @@
 #include "kernels/emission/compton.hpp"
 #include "kernels/emission/emission.hpp"
 #include "kernels/emission/synchrotron.hpp"
+#include "kernels/emission/traits.h"
 #include "kernels/particle_pusher_sr.hpp"
 
 namespace ntt {
@@ -69,6 +70,10 @@ namespace ntt {
           domain.index(),
           params,
           domain.random_pool());
+        static_assert(
+          kernel::traits::emission::IsValid<kernel::emission::Synchrotron<M>, M>,
+          "Synchrotron emission policy does not satisfy the required "
+          "interface");
         Kokkos::parallel_for(
           "ParticlePusher",
           range,
@@ -109,6 +114,9 @@ namespace ntt {
           domain.index(),
           params,
           domain.random_pool());
+        static_assert(
+          kernel::traits::emission::IsValid<kernel::emission::Compton<M>, M>,
+          "Compton emission policy does not satisfy the required interface");
         Kokkos::parallel_for(
           "ParticlePusher",
           range,

--- a/src/engines/srpic/particle_pusher.h
+++ b/src/engines/srpic/particle_pusher.h
@@ -16,7 +16,6 @@
 #include "framework/domain/domain.h"
 #include "framework/domain/grid.h"
 #include "framework/parameters/parameters.h"
-
 #include "kernels/emission/compton.hpp"
 #include "kernels/emission/emission.hpp"
 #include "kernels/emission/synchrotron.hpp"
@@ -25,7 +24,7 @@
 namespace ntt {
   namespace srpic {
 
-    template <class M, class F, bool Atm>
+    template <class M, class F, class PG, bool Atm>
     void CallPusher(Domain<SimEngine::SRPIC, M>&    domain,
                     const SimulationParams&         params,
                     const kernel::sr::PusherParams& pusher_params,
@@ -34,6 +33,7 @@ namespace ntt {
                     const range_t<Dim::_1D>&        range,
                     const ndfield_t<M::Dim, 6>&     EB,
                     const M&                        metric,
+                    const PG&                       pgen,
                     const F&                        external_fields) {
       if (emission_policy_flag == EmissionType::NONE) {
         const auto no_emission = kernel::NoEmissionPolicy_t<SimEngine::SRPIC, M> {};
@@ -62,6 +62,7 @@ namespace ntt {
                        HERE);
         const auto emission_policy = kernel::emission::Synchrotron<M>(
           emitted_species,
+          photon_species,
           pusher_params.mass,
           pusher_params.charge,
           pusher_params.radiative_drag_flags,
@@ -79,11 +80,14 @@ namespace ntt {
             metric,
             external_fields,
             emission_policy));
-        const auto n_inj = emission_policy.number_injected();
+        const auto n_inj = emission_policy.numbers_injected();
+        raise::ErrorIf(n_inj.size() != 1,
+                       "Synchrotron emission should only inject one species",
+                       HERE);
         domain.species[photon_species - 1].set_npart(
-          emitted_species.npart() + n_inj);
+          emitted_species.npart() + n_inj[0]);
         domain.species[photon_species - 1].set_counter(
-          emitted_species.counter() + n_inj);
+          emitted_species.counter() + n_inj[0]);
       } else if (emission_policy_flag == EmissionType::COMPTON) {
         const auto photon_species = params.get<spidx_t>(
           "radiation.emission.compton.photon_species");
@@ -99,6 +103,7 @@ namespace ntt {
                        HERE);
         const auto emission_policy = kernel::emission::Compton<M>(
           emitted_species,
+          photon_species,
           pusher_params.mass,
           pusher_params.charge,
           pusher_params.radiative_drag_flags,
@@ -116,11 +121,59 @@ namespace ntt {
             metric,
             external_fields,
             emission_policy));
-        const auto n_inj = emission_policy.number_injected();
+        const auto n_inj = emission_policy.numbers_injected();
+        raise::ErrorIf(n_inj.size() != 1,
+                       "Compton emission should only inject one species",
+                       HERE);
         domain.species[photon_species - 1].set_npart(
-          emitted_species.npart() + n_inj);
+          emitted_species.npart() + n_inj[0]);
         domain.species[photon_species - 1].set_counter(
-          emitted_species.counter() + n_inj);
+          emitted_species.counter() + n_inj[0]);
+      } else if (emission_policy_flag == EmissionType::CUSTOM) {
+        if constexpr (
+          arch::traits::pgen::HasEmissionPolicy<PG, M, decltype(domain)>) {
+          const auto emission_policy = pgen.EmissionPolicy(pusher_params.time,
+                                                           pusher_params.species_index,
+                                                           domain,
+                                                           params);
+          static_assert(
+            kernel::traits::emission::IsValid<decltype(emission_policy), M>,
+            "Custom emission policy does not satisfy the required "
+            "interface");
+          Kokkos::parallel_for(
+            "ParticlePusher",
+            range,
+            kernel::sr::Pusher_kernel<M, F, Atm, decltype(emission_policy)>(
+              pusher_params,
+              pusher_arrays,
+              EB,
+              metric,
+              external_fields,
+              emission_policy));
+          const auto emitted_species = emission_policy.emitted_species_indices();
+          const auto n_inj = emission_policy.number_injected();
+          raise::ErrorIf(emitted_species.size() != n_inj.size(),
+                         "Emission policy emitted_species_indices and "
+                         "numbers_injected must have the same size",
+                         HERE);
+          for (auto i = 0u; i < emitted_species.size(); ++i) {
+            const auto sp_idx = emitted_species[i];
+            raise::ErrorIf(sp_idx > domain.species.size(),
+                           "Invalid emitted species index from custom "
+                           "emission policy",
+                           HERE);
+            domain.species[sp_idx - 1].set_npart(
+              domain.species[sp_idx - 1].npart() + n_inj[i]);
+            domain.species[sp_idx - 1].set_counter(
+              domain.species[sp_idx - 1].counter() + n_inj[i]);
+          }
+        } else {
+          raise::Error("Custom emission policy flag is set but problem "
+                       "generator does not define an emission policy",
+                       HERE);
+        }
+      } else {
+        raise::Error("Unrecognized emission policy flag", HERE);
       }
     }
 
@@ -184,6 +237,7 @@ namespace ntt {
           HERE);
 
         kernel::sr::PusherParams pusher_params {};
+        pusher_params.species_index        = species.index();
         pusher_params.pusher_flags         = species.pusher();
         pusher_params.radiative_drag_flags = species.radiative_drag_flags();
         pusher_params.mass                 = species.mass();
@@ -226,26 +280,7 @@ namespace ntt {
             params.template get<real_t>("radiation.drag.compton.gamma_rad"));
         }
 
-        kernel::sr::PusherArrays pusher_arrays {};
-        pusher_arrays.sp       = species.index();
-        pusher_arrays.i1       = species.i1;
-        pusher_arrays.i2       = species.i2;
-        pusher_arrays.i3       = species.i3;
-        pusher_arrays.i1_prev  = species.i1_prev;
-        pusher_arrays.i2_prev  = species.i2_prev;
-        pusher_arrays.i3_prev  = species.i3_prev;
-        pusher_arrays.dx1      = species.dx1;
-        pusher_arrays.dx2      = species.dx2;
-        pusher_arrays.dx3      = species.dx3;
-        pusher_arrays.dx1_prev = species.dx1_prev;
-        pusher_arrays.dx2_prev = species.dx2_prev;
-        pusher_arrays.dx3_prev = species.dx3_prev;
-        pusher_arrays.ux1      = species.ux1;
-        pusher_arrays.ux2      = species.ux2;
-        pusher_arrays.ux3      = species.ux3;
-        pusher_arrays.phi      = species.phi;
-        pusher_arrays.weight   = species.weight;
-        pusher_arrays.tag      = species.tag;
+        auto pusher_arrays = species.PusherKernelArrays();
 
         // toggle to indicate whether pgen defines the external force
         bool has_extfields = false;
@@ -261,7 +296,7 @@ namespace ntt {
         }
 
         if (not has_atmosphere and not has_extfields) {
-          CallPusher<M, kernel::sr::NoField_t, false>(
+          CallPusher<M, kernel::sr::NoField_t, decltype(pgen), false>(
             domain,
             params,
             pusher_params,
@@ -270,9 +305,10 @@ namespace ntt {
             species.rangeActiveParticles(),
             domain.fields.em,
             domain.mesh.metric,
+            pgen,
             kernel::sr::NoField_t {});
         } else if (has_atmosphere and not has_extfields) {
-          CallPusher<M, kernel::sr::NoField_t, true>(
+          CallPusher<M, kernel::sr::NoField_t, decltype(pgen), true>(
             domain,
             params,
             pusher_params,
@@ -281,10 +317,11 @@ namespace ntt {
             species.rangeActiveParticles(),
             domain.fields.em,
             domain.mesh.metric,
+            pgen,
             kernel::sr::NoField_t {});
         } else if (not has_atmosphere and has_extfields) {
           if constexpr (arch::traits::pgen::HasExtFields<PG>) {
-            CallPusher<M, decltype(pgen.ext_fields), false>(
+            CallPusher<M, decltype(pgen.ext_fields), decltype(pgen), false>(
               domain,
               params,
               pusher_params,
@@ -293,13 +330,14 @@ namespace ntt {
               species.rangeActiveParticles(),
               domain.fields.em,
               domain.mesh.metric,
+              pgen,
               pgen.ext_fields);
           } else {
             raise::Error("External fields not implemented", HERE);
           }
         } else { // has_atmosphere and has_extforce
           if constexpr (arch::traits::pgen::HasExtFields<PG>) {
-            CallPusher<M, decltype(pgen.ext_fields), true>(
+            CallPusher<M, decltype(pgen.ext_fields), decltype(pgen), true>(
               domain,
               params,
               pusher_params,
@@ -308,6 +346,7 @@ namespace ntt {
               species.rangeActiveParticles(),
               domain.fields.em,
               domain.mesh.metric,
+              pgen,
               pgen.ext_fields);
           } else {
             raise::Error("External fields not implemented", HERE);

--- a/src/engines/srpic/particle_pusher.h
+++ b/src/engines/srpic/particle_pusher.h
@@ -134,8 +134,7 @@ namespace ntt {
           arch::traits::pgen::HasEmissionPolicy<PG, M, decltype(domain)>) {
           const auto emission_policy = pgen.EmissionPolicy(pusher_params.time,
                                                            pusher_params.species_index,
-                                                           domain,
-                                                           params);
+                                                           domain);
           static_assert(
             kernel::traits::emission::IsValid<decltype(emission_policy), M>,
             "Custom emission policy does not satisfy the required "
@@ -151,7 +150,7 @@ namespace ntt {
               external_fields,
               emission_policy));
           const auto emitted_species = emission_policy.emitted_species_indices();
-          const auto n_inj = emission_policy.number_injected();
+          const auto n_inj = emission_policy.numbers_injected();
           raise::ErrorIf(emitted_species.size() != n_inj.size(),
                          "Emission policy emitted_species_indices and "
                          "numbers_injected must have the same size",

--- a/src/engines/srpic/particle_pusher.h
+++ b/src/engines/srpic/particle_pusher.h
@@ -66,7 +66,6 @@ namespace ntt {
           pusher_params.mass,
           pusher_params.charge,
           pusher_params.radiative_drag_flags,
-          pusher_params.dt,
           domain.index(),
           params,
           domain.random_pool());
@@ -107,7 +106,6 @@ namespace ntt {
           pusher_params.mass,
           pusher_params.charge,
           pusher_params.radiative_drag_flags,
-          pusher_params.dt,
           domain.index(),
           params,
           domain.random_pool());

--- a/src/engines/srpic/particles_bcs.h
+++ b/src/engines/srpic/particles_bcs.h
@@ -16,7 +16,6 @@
 #include "framework/domain/domain.h"
 #include "framework/domain/metadomain.h"
 #include "framework/parameters/parameters.h"
-
 #include "kernels/particle_moments.hpp"
 
 namespace ntt {

--- a/src/engines/srpic/srpic.hpp
+++ b/src/engines/srpic/srpic.hpp
@@ -69,8 +69,6 @@ namespace ntt {
         "algorithms.fieldsolver.enable");
       const auto deposit_enabled = m_params.template get<bool>(
         "algorithms.deposit.enable");
-      const auto clear_interval = m_params.template get<std::size_t>(
-        "particles.clear_interval");
 
       if (step == 0) {
         // communicate fields and apply BCs on the first timestep

--- a/src/framework/containers/particles.cpp
+++ b/src/framework/containers/particles.cpp
@@ -84,6 +84,31 @@ namespace ntt {
     }
   }
 
+  template <Dimension D, Coord::type C>
+  auto Particles<D, C>::PusherKernelArrays() -> kernel::sr::PusherArrays {
+    kernel::sr::PusherArrays pusher_arrays {};
+    pusher_arrays.sp       = index();
+    pusher_arrays.i1       = i1;
+    pusher_arrays.i2       = i2;
+    pusher_arrays.i3       = i3;
+    pusher_arrays.i1_prev  = i1_prev;
+    pusher_arrays.i2_prev  = i2_prev;
+    pusher_arrays.i3_prev  = i3_prev;
+    pusher_arrays.dx1      = dx1;
+    pusher_arrays.dx2      = dx2;
+    pusher_arrays.dx3      = dx3;
+    pusher_arrays.dx1_prev = dx1_prev;
+    pusher_arrays.dx2_prev = dx2_prev;
+    pusher_arrays.dx3_prev = dx3_prev;
+    pusher_arrays.ux1      = ux1;
+    pusher_arrays.ux2      = ux2;
+    pusher_arrays.ux3      = ux3;
+    pusher_arrays.phi      = phi;
+    pusher_arrays.weight   = weight;
+    pusher_arrays.tag      = tag;
+    return pusher_arrays;
+  }
+
   template struct Particles<Dim::_1D, Coord::Cart>;
   template struct Particles<Dim::_2D, Coord::Cart>;
   template struct Particles<Dim::_3D, Coord::Cart>;

--- a/src/framework/containers/particles.h
+++ b/src/framework/containers/particles.h
@@ -25,6 +25,7 @@
 
 #include "framework/containers/species.h"
 #include "framework/domain/grid.h"
+#include "kernels/particle_pusher_sr.hpp"
 
 #include <Kokkos_Core.hpp>
 
@@ -269,6 +270,12 @@ namespace ntt {
      * @brief Copy particle data from device to host.
      */
     void SyncHostDevice();
+
+    /**
+     * @brief Get the arrays required for the particle pusher kernel
+     * @returns The struct of arrays for the particle pusher kernel
+     */
+    auto PusherKernelArrays() -> kernel::sr::PusherArrays;
 
 #if defined(MPI_ENABLED)
     /**

--- a/src/framework/containers/particles_comm.cpp
+++ b/src/framework/containers/particles_comm.cpp
@@ -10,7 +10,6 @@
 #include "utils/log.h"
 
 #include "framework/containers/particles.h"
-
 #include "kernels/comm.hpp"
 
 #include <mpi.h>

--- a/src/framework/containers/particles_io.cpp
+++ b/src/framework/containers/particles_io.cpp
@@ -7,10 +7,9 @@
 
 #include "framework/containers/particles.h"
 #include "framework/specialization_registry.h"
+#include "kernels/prtls_to_phys.hpp"
 #include "output/utils/readers.h"
 #include "output/utils/writers.h"
-
-#include "kernels/prtls_to_phys.hpp"
 
 #include <Kokkos_Core.hpp>
 #include <adios2.h>

--- a/src/framework/containers/particles_io.cpp
+++ b/src/framework/containers/particles_io.cpp
@@ -122,7 +122,10 @@ namespace ntt {
 
     npart_t nout_offset = 0;
     npart_t nout_total  = nout;
-#if defined(MPI_ENABLED)
+#if !defined(MPI_ENABLED)
+    (void)domains_total;
+    (void)domains_offset;
+#else
     auto nout_total_vec = std::vector<npart_t>(domains_total);
     MPI_Allgather(&nout,
                   1,
@@ -428,7 +431,9 @@ namespace ntt {
                                domains_offset);
     set_npart(npart_read);
 
-#if defined(MPI_ENABLED)
+#if !defined(MPI_ENABLED)
+    (void)domains_total;
+#else
     {
       const auto           npart_send = npart();
       std::vector<npart_t> glob_nparts(domains_total);

--- a/src/framework/containers/particles_io.cpp
+++ b/src/framework/containers/particles_io.cpp
@@ -132,7 +132,7 @@ namespace ntt {
                   mpi::get_type<npart_t>(),
                   MPI_COMM_WORLD);
     nout_total = 0;
-    for (auto r = 0; r < domains_total; ++r) {
+    for (auto r = 0u; r < domains_total; ++r) {
       if (r < domains_offset) {
         nout_offset += nout_total_vec[r];
       }
@@ -615,7 +615,7 @@ namespace ntt {
                     mpi::get_type<npart_t>(),
                     MPI_COMM_WORLD);
       npart_total = 0u;
-      for (auto r = 0; r < domains_total; ++r) {
+      for (auto r = 0u; r < domains_total; ++r) {
         if (r < domains_offset) {
           npart_offset += glob_nparts[r];
         }

--- a/src/framework/containers/species.h
+++ b/src/framework/containers/species.h
@@ -32,10 +32,10 @@ namespace ntt {
     const float       m_charge;
     // Max number of allocated particles for the species
     npart_t           m_maxnpart;
+    // Clearing interval for the species (0 means no clearing)
+    const timestep_t  m_clearing_interval;
     // Spatial sorting interval for the species (0 means no sorting)
     const timestep_t  m_spatial_sorting_interval;
-    // Spatial sorting interval for the species (0 means no clearing)
-    const timestep_t  m_clearing_interval;
 
     // Pusher assigned for the species
     const ParticlePusherFlags m_particle_pusher_flags;

--- a/src/framework/domain/metadomain_chckpt.cpp
+++ b/src/framework/domain/metadomain_chckpt.cpp
@@ -1,5 +1,3 @@
-#include "output/checkpoint.h"
-
 #include "enums.h"
 #include "global.h"
 
@@ -10,6 +8,7 @@
 #include "framework/domain/metadomain.h"
 #include "framework/parameters/parameters.h"
 #include "framework/specialization_registry.h"
+#include "output/checkpoint.h"
 
 namespace ntt {
 

--- a/src/framework/domain/metadomain_io.cpp
+++ b/src/framework/domain/metadomain_io.cpp
@@ -80,10 +80,6 @@ namespace ntt {
       "output.particles.species");
     g_writer.defineFieldOutputs(S, all_fields_to_write);
 
-    Dimension dim = M::PrtlDim;
-    if constexpr (M::CoordType != Coord::Cart) {
-      dim = Dim::_3D;
-    }
     g_writer.clearSpeciesIndex();
     for (const auto& s : species_to_write) {
       g_writer.addSpeciesIndex(s);
@@ -280,7 +276,7 @@ namespace ntt {
         for (auto nr1 { 0u }; nr1 < nranks_x1; ++nr1) {
           const auto rank_send = rank_send_pre + nr1;
           const auto rank_recv = rank_recv_pre + nr1;
-          if (local_domain->mpi_rank() == rank_send) {
+          if (static_cast<unsigned int>(local_domain->mpi_rank()) == rank_send) {
             array_t<real_t*> aphi_r { "Aphi_r", nx1 };
             Kokkos::deep_copy(
               aphi_r,
@@ -294,7 +290,8 @@ namespace ntt {
                      rank_recv,
                      0,
                      MPI_COMM_WORLD);
-          } else if (local_domain->mpi_rank() == rank_recv) {
+          } else if (static_cast<unsigned int>(local_domain->mpi_rank()) ==
+                     rank_recv) {
             array_t<real_t*> aphi_r { "Aphi_r", nx1 };
             MPI_Recv(aphi_r.data(),
                      nx1,

--- a/src/framework/domain/metadomain_io.cpp
+++ b/src/framework/domain/metadomain_io.cpp
@@ -11,7 +11,6 @@
 #include "framework/domain/metadomain.h"
 #include "framework/parameters/parameters.h"
 #include "framework/specialization_registry.h"
-
 #include "kernels/divergences.hpp"
 #include "kernels/fields_to_phys.hpp"
 #include "kernels/particle_moments.hpp"

--- a/src/framework/domain/metadomain_sort.cpp
+++ b/src/framework/domain/metadomain_sort.cpp
@@ -11,9 +11,9 @@ namespace ntt {
   template <SimEngine::type S, class M>
     requires IsCompatibleWithMetadomain<M>
   void Metadomain<S, M>::SortParticles(simtime_t,
-                                       timestep_t              step,
-                                       const SimulationParams& params,
-                                       Domain<S, M>&           domain) const {
+                                       timestep_t step,
+                                       const SimulationParams&,
+                                       Domain<S, M>& domain) const {
     for (auto& species : domain.species) {
       const auto clearing_interval = species.clearing_interval();
       if ((clearing_interval > 0u) and (step % clearing_interval == 0u) and

--- a/src/framework/domain/metadomain_stats.cpp
+++ b/src/framework/domain/metadomain_stats.cpp
@@ -11,7 +11,6 @@
 #include "framework/domain/metadomain.h"
 #include "framework/parameters/parameters.h"
 #include "framework/specialization_registry.h"
-
 #include "kernels/reduced_stats.hpp"
 
 #include <Kokkos_Core.hpp>
@@ -190,8 +189,8 @@ namespace ntt {
     timestep_t              finished_step,
     simtime_t               current_time,
     simtime_t               finished_time,
-    std::function<real_t(const std::string&, timestep_t, simtime_t, const Domain<S, M>&)>
-      CustomStat) -> bool {
+    std::function<real_t(const std::string&, timestep_t, simtime_t, const Domain<S, M>&)> CustomStat)
+    -> bool {
     if (not(params.template get<bool>("output.stats.enable") and
             g_stats_writer.shouldWrite(finished_step, finished_time))) {
       return false;
@@ -281,17 +280,18 @@ namespace ntt {
     return true;
   }
 
-#define METADOMAIN_STATS(S, M, D)                                              \
-  template void Metadomain<S, M<D>>::InitStatsWriter(const SimulationParams&,  \
-                                                     bool);                    \
-  template auto Metadomain<S, M<D>>::WriteStats(                               \
-    const SimulationParams&,                                                   \
-    timestep_t,                                                                \
-    timestep_t,                                                                \
-    simtime_t,                                                                 \
-    simtime_t,                                                                 \
-    std::function<                                                             \
-      real_t(const std::string&, timestep_t, simtime_t, const Domain<S, M<D>>&)>) -> bool;
+#define METADOMAIN_STATS(S, M, D)                                                 \
+  template void Metadomain<S, M<D>>::InitStatsWriter(const SimulationParams&,     \
+                                                     bool);                       \
+  template auto Metadomain<S, M<D>>::WriteStats(                                  \
+    const SimulationParams&,                                                      \
+    timestep_t,                                                                   \
+    timestep_t,                                                                   \
+    simtime_t,                                                                    \
+    simtime_t,                                                                    \
+    std::function<                                                                \
+      real_t(const std::string&, timestep_t, simtime_t, const Domain<S, M<D>>&)>) \
+    -> bool;
 
   NTT_FOREACH_SPECIALIZATION(METADOMAIN_STATS)
 

--- a/src/framework/parameters/algorithms.cpp
+++ b/src/framework/parameters/algorithms.cpp
@@ -4,9 +4,10 @@
 #include "global.h"
 
 #include "utils/numeric.h"
-#include <toml11/toml.hpp>
 
 #include "framework/parameters/parameters.h"
+
+#include <toml11/toml.hpp>
 
 namespace ntt {
   namespace params {

--- a/src/framework/parameters/algorithms.h
+++ b/src/framework/parameters/algorithms.h
@@ -14,9 +14,9 @@
 
 #include "global.h"
 
-#include <toml11/toml.hpp>
-
 #include "framework/parameters/parameters.h"
+
+#include <toml11/toml.hpp>
 
 #include <map>
 #include <string>

--- a/src/framework/parameters/extra.h
+++ b/src/framework/parameters/extra.h
@@ -14,9 +14,9 @@
 
 #include "global.h"
 
-#include <toml11/toml.hpp>
-
 #include "framework/parameters/parameters.h"
+
+#include <toml11/toml.hpp>
 
 #include <map>
 #include <string>

--- a/src/framework/parameters/grid.cpp
+++ b/src/framework/parameters/grid.cpp
@@ -6,7 +6,6 @@
 #include "utils/error.h"
 #include "utils/formatting.h"
 #include "utils/numeric.h"
-#include <toml11/toml.hpp>
 
 #include "metrics/kerr_schild.h"
 #include "metrics/kerr_schild_0.h"
@@ -16,6 +15,8 @@
 #include "metrics/spherical.h"
 
 #include "framework/parameters/parameters.h"
+
+#include <toml11/toml.hpp>
 
 #include <map>
 #include <string>

--- a/src/framework/parameters/grid.h
+++ b/src/framework/parameters/grid.h
@@ -15,9 +15,9 @@
 #include "enums.h"
 #include "global.h"
 
-#include <toml11/toml.hpp>
-
 #include "framework/parameters/parameters.h"
+
+#include <toml11/toml.hpp>
 
 #include <map>
 #include <tuple>

--- a/src/framework/parameters/output.cpp
+++ b/src/framework/parameters/output.cpp
@@ -5,6 +5,7 @@
 
 #include "utils/error.h"
 #include "utils/log.h"
+
 #include <toml11/toml.hpp>
 
 namespace ntt {

--- a/src/framework/parameters/output.h
+++ b/src/framework/parameters/output.h
@@ -14,9 +14,9 @@
 
 #include "global.h"
 
-#include <toml11/toml.hpp>
-
 #include "framework/parameters/parameters.h"
+
+#include <toml11/toml.hpp>
 
 #include <map>
 #include <string>

--- a/src/framework/parameters/particles.cpp
+++ b/src/framework/parameters/particles.cpp
@@ -86,6 +86,8 @@ namespace ntt {
         return EmissionType::SYNCHROTRON;
       } else if (fmt::toLower(emission_policy_str) == "compton") {
         return EmissionType::COMPTON;
+      } else if (fmt::toLower(emission_policy_str) == "custom") {
+        return EmissionType::CUSTOM;
       } else {
         raise::Error(fmt::format("Invalid emission_policy value: %s",
                                  emission_policy_str.c_str()),

--- a/src/framework/simulation.cpp
+++ b/src/framework/simulation.cpp
@@ -9,6 +9,7 @@
 #include "utils/formatting.h"
 #include "utils/log.h"
 #include "utils/plog.h"
+
 #include <toml11/toml.hpp>
 
 #include <filesystem>

--- a/src/framework/simulation.h
+++ b/src/framework/simulation.h
@@ -17,10 +17,11 @@
 #include "enums.h"
 
 #include "utils/error.h"
-#include <toml11/toml.hpp>
 
 #include "engines/traits.h"
 #include "framework/parameters/parameters.h"
+
+#include <toml11/toml.hpp>
 
 namespace ntt {
 

--- a/src/framework/tests/comm-mpi.cpp
+++ b/src/framework/tests/comm-mpi.cpp
@@ -1,5 +1,3 @@
-#include "framework/domain/comm_mpi.hpp"
-
 #include "enums.h"
 #include "global.h"
 
@@ -7,6 +5,8 @@
 #include "arch/kokkos_aliases.h"
 #include "utils/error.h"
 #include "utils/numeric.h"
+
+#include "framework/domain/comm_mpi.hpp"
 
 #include <Kokkos_Core.hpp>
 #include <mpi.h>

--- a/src/framework/tests/comm-nompi.cpp
+++ b/src/framework/tests/comm-nompi.cpp
@@ -1,11 +1,11 @@
-#include "framework/domain/comm_nompi.hpp"
-
 #include "enums.h"
 #include "global.h"
 
 #include "arch/directions.h"
 #include "arch/kokkos_aliases.h"
 #include "utils/numeric.h"
+
+#include "framework/domain/comm_nompi.hpp"
 
 #include <iostream>
 #include <stdexcept>

--- a/src/global/arch/directions.h
+++ b/src/global/arch/directions.h
@@ -132,8 +132,8 @@ namespace dir {
   using dirs_t = std::vector<direction_t<D>>;
 
   template <Dimension D>
-  inline auto operator<<(std::ostream&         os,
-                         const direction_t<D>& dir) -> std::ostream& {
+  inline auto operator<<(std::ostream& os, const direction_t<D>& dir)
+    -> std::ostream& {
     for (auto& d : dir) {
       os << std::setw(2) << std::left;
       if (d > 0) {

--- a/src/global/arch/kokkos_aliases.cpp
+++ b/src/global/arch/kokkos_aliases.cpp
@@ -9,18 +9,18 @@ auto CreateParticleRangePolicy(npart_t p1, npart_t p2) -> range_t<Dim::_1D> {
 }
 
 template <>
-auto CreateRangePolicy<Dim::_1D>(
-  const tuple_t<ncells_t, Dim::_1D>& i1,
-  const tuple_t<ncells_t, Dim::_1D>& i2) -> range_t<Dim::_1D> {
+auto CreateRangePolicy<Dim::_1D>(const tuple_t<ncells_t, Dim::_1D>& i1,
+                                 const tuple_t<ncells_t, Dim::_1D>& i2)
+  -> range_t<Dim::_1D> {
   index_t i1min = i1[0];
   index_t i1max = i2[0];
   return Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(i1min, i1max);
 }
 
 template <>
-auto CreateRangePolicy<Dim::_2D>(
-  const tuple_t<ncells_t, Dim::_2D>& i1,
-  const tuple_t<ncells_t, Dim::_2D>& i2) -> range_t<Dim::_2D> {
+auto CreateRangePolicy<Dim::_2D>(const tuple_t<ncells_t, Dim::_2D>& i1,
+                                 const tuple_t<ncells_t, Dim::_2D>& i2)
+  -> range_t<Dim::_2D> {
   index_t i1min = i1[0];
   index_t i1max = i2[0];
   index_t i2min = i1[1];
@@ -31,9 +31,9 @@ auto CreateRangePolicy<Dim::_2D>(
 }
 
 template <>
-auto CreateRangePolicy<Dim::_3D>(
-  const tuple_t<ncells_t, Dim::_3D>& i1,
-  const tuple_t<ncells_t, Dim::_3D>& i2) -> range_t<Dim::_3D> {
+auto CreateRangePolicy<Dim::_3D>(const tuple_t<ncells_t, Dim::_3D>& i1,
+                                 const tuple_t<ncells_t, Dim::_3D>& i2)
+  -> range_t<Dim::_3D> {
   index_t i1min = i1[0];
   index_t i1max = i2[0];
   index_t i2min = i1[1];
@@ -46,18 +46,18 @@ auto CreateRangePolicy<Dim::_3D>(
 }
 
 template <>
-auto CreateRangePolicyOnHost<Dim::_1D>(
-  const tuple_t<ncells_t, Dim::_1D>& i1,
-  const tuple_t<ncells_t, Dim::_1D>& i2) -> range_h_t<Dim::_1D> {
+auto CreateRangePolicyOnHost<Dim::_1D>(const tuple_t<ncells_t, Dim::_1D>& i1,
+                                       const tuple_t<ncells_t, Dim::_1D>& i2)
+  -> range_h_t<Dim::_1D> {
   index_t i1min = i1[0];
   index_t i1max = i2[0];
   return Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(i1min, i1max);
 }
 
 template <>
-auto CreateRangePolicyOnHost<Dim::_2D>(
-  const tuple_t<ncells_t, Dim::_2D>& i1,
-  const tuple_t<ncells_t, Dim::_2D>& i2) -> range_h_t<Dim::_2D> {
+auto CreateRangePolicyOnHost<Dim::_2D>(const tuple_t<ncells_t, Dim::_2D>& i1,
+                                       const tuple_t<ncells_t, Dim::_2D>& i2)
+  -> range_h_t<Dim::_2D> {
   index_t i1min = i1[0];
   index_t i1max = i2[0];
   index_t i2min = i1[1];
@@ -68,9 +68,9 @@ auto CreateRangePolicyOnHost<Dim::_2D>(
 }
 
 template <>
-auto CreateRangePolicyOnHost<Dim::_3D>(
-  const tuple_t<ncells_t, Dim::_3D>& i1,
-  const tuple_t<ncells_t, Dim::_3D>& i2) -> range_h_t<Dim::_3D> {
+auto CreateRangePolicyOnHost<Dim::_3D>(const tuple_t<ncells_t, Dim::_3D>& i1,
+                                       const tuple_t<ncells_t, Dim::_3D>& i2)
+  -> range_h_t<Dim::_3D> {
   index_t i1min = i1[0];
   index_t i1max = i2[0];
   index_t i2min = i1[1];

--- a/src/global/arch/mpi_tags.h
+++ b/src/global/arch/mpi_tags.h
@@ -190,13 +190,8 @@ namespace mpi {
            tag;
   }
 
-  Inline auto SendTag(short tag,
-                      bool  im1,
-                      bool  ip1,
-                      bool  jm1,
-                      bool  jp1,
-                      bool  km1,
-                      bool  kp1) -> short {
+  Inline auto SendTag(short tag, bool im1, bool ip1, bool jm1, bool jp1, bool km1, bool kp1)
+    -> short {
     return ((im1 && jm1 && km1) * (PrtlSendTag<Dim::_3D>::im1_jm1_km1 - 1) +
             (im1 && jm1 && kp1) * (PrtlSendTag<Dim::_3D>::im1_jm1_kp1 - 1) +
             (im1 && jp1 && km1) * (PrtlSendTag<Dim::_3D>::im1_jp1_km1 - 1) +

--- a/src/global/arch/traits.h
+++ b/src/global/arch/traits.h
@@ -169,45 +169,6 @@ namespace traits {
 
   } // namespace external
 
-  namespace emission {
-
-    template <class E>
-    concept HasPayloadType = requires { typename E::Payload; };
-
-    template <class E, Dimension D>
-    concept HasShouldEmit = HasPayloadType<E> and requires(
-                                                    const E&               e,
-                                                    const coord_t<D>&      x_Cd,
-                                                    const coord_t<D>&      x_Ph,
-                                                    const vec_t<Dim::_3D>& u_Ph,
-                                                    const vec_t<Dim::_3D>& ep,
-                                                    const vec_t<Dim::_3D>& bp,
-                                                    vec_t<Dim::_3D>& delta_u_Ph,
-                                                    typename E::Payload& payload) {
-      {
-        e.shouldEmit(x_Cd, x_Ph, u_Ph, ep, bp, delta_u_Ph, payload)
-      } -> std::convertible_to<Kokkos::pair<bool, bool>>;
-    };
-
-    template <class E, Dimension D>
-    concept HasEmit = HasPayloadType<E> and
-                      requires(const E&                    e,
-                               const tuple_t<int, D>&      xi_Cd,
-                               const tuple_t<prtldx_t, D>& dxi_Cd,
-                               const vec_t<Dim::_3D>&      direction,
-                               real_t                      weight,
-                               real_t                      phi,
-                               const typename E::Payload&  payload) {
-                        {
-                          e.emit(xi_Cd, dxi_Cd, direction, weight, phi, payload)
-                        } -> std::same_as<void>;
-                      };
-
-    template <class E, Dimension D>
-    concept IsValidEmissionPolicy = HasShouldEmit<E, D> and HasEmit<E, D>;
-
-  } // namespace emission
-
   template <template <typename> class Trait, typename T, typename = void>
   struct has_method : std::false_type {};
 

--- a/src/global/enums.h
+++ b/src/global/enums.h
@@ -17,7 +17,7 @@
  *
  *   - enum ntt::ParticlePusher    // photon, boris, vay, gca, none
  *   - enum ntt::RadiativeDrag     // compton, synchrotron, none
- *   - enum ntt::EmissionType      // none, synchrotron, inversecompton
+ *   - enum ntt::EmissionType      // none, synchrotron, inversecompton, custom
  *
  * @namespaces:
  *   - ntt::
@@ -371,6 +371,7 @@ namespace ntt {
       NONE        = 0,
       SYNCHROTRON = 1,
       COMPTON     = 2,
+      CUSTOM      = 3,
     };
 
     inline auto to_string(int flags) -> std::string {
@@ -381,6 +382,8 @@ namespace ntt {
           return "synchrotron";
         case COMPTON:
           return "compton";
+        case CUSTOM:
+          return "custom";
         default:
           return "unknown";
       }

--- a/src/global/utils/cargs.cpp
+++ b/src/global/utils/cargs.cpp
@@ -18,8 +18,8 @@ namespace cargs {
     _initialized = true;
   }
 
-  auto CommandLineArguments::getArgument(std::string_view key,
-                                         std::string_view def) -> std::string_view {
+  auto CommandLineArguments::getArgument(std::string_view key, std::string_view def)
+    -> std::string_view {
     if (!_initialized) {
       throw std::runtime_error(
         "# Error: command line arguments have not been parsed.");

--- a/src/global/utils/cargs.h
+++ b/src/global/utils/cargs.h
@@ -25,7 +25,8 @@ namespace cargs {
   public:
     void readCommandLineArguments(int argc, char* argv[]);
     [[nodiscard]]
-    auto getArgument(std::string_view key, std::string_view def) -> std::string_view;
+    auto getArgument(std::string_view key, std::string_view def)
+      -> std::string_view;
     [[nodiscard]]
     auto getArgument(std::string_view key) -> std::string_view;
     auto isSpecified(std::string_view key) -> bool;

--- a/src/global/utils/comparators.h
+++ b/src/global/utils/comparators.h
@@ -27,31 +27,31 @@
 namespace cmp {
 
   template <class T>
-  Inline auto AlmostEqual(T a,
-                          T b,
-                          T eps = Kokkos::Experimental::epsilon<T>::value) -> bool {
+  Inline auto AlmostEqual(T a, T b, T eps = Kokkos::Experimental::epsilon<T>::value)
+    -> bool {
     static_assert(std::is_floating_point_v<T>, "T must be a floating point type");
     return (a == b) ||
            (math::abs(a - b) <= math::min(math::abs(a), math::abs(b)) * eps);
   }
 
   template <class T>
-  Inline auto AlmostZero(T a, T eps = Kokkos::Experimental::epsilon<T>::value) -> bool {
+  Inline auto AlmostZero(T a, T eps = Kokkos::Experimental::epsilon<T>::value)
+    -> bool {
     static_assert(std::is_floating_point_v<T>, "T must be a floating point type");
     return math::abs(a) <= eps;
   }
 
   template <class T>
-  inline auto AlmostEqual_host(T a,
-                               T b,
-                               T eps = std::numeric_limits<T>::epsilon()) -> bool {
+  inline auto AlmostEqual_host(T a, T b, T eps = std::numeric_limits<T>::epsilon())
+    -> bool {
     static_assert(std::is_floating_point_v<T>, "T must be a floating point type");
     return (a == b) ||
            (std::abs(a - b) <= std::min(std::abs(a), std::abs(b)) * eps);
   }
 
   template <class T>
-  inline auto AlmostZero_host(T a, T eps = std::numeric_limits<T>::epsilon()) -> bool {
+  inline auto AlmostZero_host(T a, T eps = std::numeric_limits<T>::epsilon())
+    -> bool {
     static_assert(std::is_floating_point_v<T>, "T must be a floating point type");
     return std::abs(a) <= eps;
   }

--- a/src/global/utils/param_container.cpp
+++ b/src/global/utils/param_container.cpp
@@ -31,8 +31,8 @@ namespace prm {
   }
 
   template <typename T>
-  auto write(adios2::IO& io, const std::string& name, T var) -> decltype(void(T()),
-                                                                         void()) {
+  auto write(adios2::IO& io, const std::string& name, T var)
+    -> decltype(void(T()), void()) {
     io.DefineAttribute(name, var);
   }
 
@@ -47,8 +47,8 @@ namespace prm {
   }
 
   template <typename T>
-  auto write_pair(adios2::IO& io, const std::string& name, std::pair<T, T> var) ->
-    typename std::enable_if<has_to_string<T>::value, void>::type {
+  auto write_pair(adios2::IO& io, const std::string& name, std::pair<T, T> var)
+    -> typename std::enable_if<has_to_string<T>::value, void>::type {
     std::vector<std::string> var_str;
     var_str.push_back(var.first.to_string());
     var_str.push_back(var.second.to_string());
@@ -56,9 +56,8 @@ namespace prm {
   }
 
   template <typename T>
-  auto write_pair(adios2::IO&        io,
-                  const std::string& name,
-                  std::pair<T, T>    var) -> decltype(void(T()), void()) {
+  auto write_pair(adios2::IO& io, const std::string& name, std::pair<T, T> var)
+    -> decltype(void(T()), void()) {
     std::vector<T> var_vec;
     var_vec.push_back(var.first);
     var_vec.push_back(var.second);
@@ -76,9 +75,8 @@ namespace prm {
   }
 
   template <typename T>
-  auto write_vec(adios2::IO&        io,
-                 const std::string& name,
-                 std::vector<T>     var) -> decltype(void(T()), void()) {
+  auto write_vec(adios2::IO& io, const std::string& name, std::vector<T> var)
+    -> decltype(void(T()), void()) {
     io.DefineAttribute(name, var.data(), var.size());
   }
 
@@ -98,8 +96,8 @@ namespace prm {
   template <typename T>
   auto write_vec_pair(adios2::IO&                  io,
                       const std::string&           name,
-                      std::vector<std::pair<T, T>> var) -> decltype(void(T()),
-                                                                    void()) {
+                      std::vector<std::pair<T, T>> var)
+    -> decltype(void(T()), void()) {
     std::vector<T> var_vec;
     for (const auto& v : var) {
       var_vec.push_back(v.first);
@@ -125,8 +123,8 @@ namespace prm {
   template <typename T>
   auto write_vec_vec(adios2::IO&                 io,
                      const std::string&          name,
-                     std::vector<std::vector<T>> var) -> decltype(void(T()),
-                                                                  void()) {
+                     std::vector<std::vector<T>> var)
+    -> decltype(void(T()), void()) {
     std::vector<T> var_vec;
     for (const auto& vec : var) {
       for (const auto& v : vec) {

--- a/src/global/utils/progressbar.cpp
+++ b/src/global/utils/progressbar.cpp
@@ -21,11 +21,10 @@
 
 namespace pbar {
 
-  auto normalize_duration_fmt(
-    duration_t         t,
-    const std::string& u) -> std::pair<duration_t, std::string> {
+  auto normalize_duration_fmt(duration_t t, const std::string& u)
+    -> std::pair<duration_t, std::string> {
     const std::vector<std::pair<std::string, duration_t>> units {
-      { "µs",   1e0 },
+      {  "µs",   1e0 },
       {  "ms",   1e3 },
       {   "s",   1e6 },
       { "min",   6e7 },

--- a/src/global/utils/progressbar.h
+++ b/src/global/utils/progressbar.h
@@ -76,9 +76,8 @@ namespace pbar {
     }
   };
 
-  auto normalize_duration_fmt(
-    duration_t         t,
-    const std::string& u) -> std::pair<duration_t, std::string>;
+  auto normalize_duration_fmt(duration_t t, const std::string& u)
+    -> std::pair<duration_t, std::string>;
 
   auto to_human_readable(duration_t t, const std::string& u) -> std::string;
 

--- a/src/global/utils/tools.h
+++ b/src/global/utils/tools.h
@@ -60,8 +60,8 @@ namespace tools {
    * @return Tensor product of list
    */
   template <typename T>
-  inline auto TensorProduct(
-    const std::vector<std::vector<T>>& list) -> std::vector<std::vector<T>> {
+  inline auto TensorProduct(const std::vector<std::vector<T>>& list)
+    -> std::vector<std::vector<T>> {
     std::vector<std::vector<T>> result = { {} };
     for (const auto& sublist : list) {
       std::vector<std::vector<T>> temp;
@@ -81,8 +81,8 @@ namespace tools {
    * @param ndomains Number of domains
    * @param ncells Number of cells
    */
-  inline auto decompose1D(unsigned int ndomains,
-                          ncells_t     ncells) -> std::vector<ncells_t> {
+  inline auto decompose1D(unsigned int ndomains, ncells_t ncells)
+    -> std::vector<ncells_t> {
     auto size          = (ncells_t)((double)ncells / (double)ndomains);
     auto ncells_domain = std::vector<ncells_t>(ndomains, size);
     for (auto i { 0u }; i < ncells - size * ndomains; ++i) {
@@ -107,10 +107,8 @@ namespace tools {
    * @param s1 Proportion of the first dimension
    * @param s2 Proportion of the second dimension
    */
-  inline auto divideInProportions2D(
-    unsigned int ntot,
-    unsigned int s1,
-    unsigned int s2) -> std::tuple<unsigned int, unsigned int> {
+  inline auto divideInProportions2D(unsigned int ntot, unsigned int s1, unsigned int s2)
+    -> std::tuple<unsigned int, unsigned int> {
     auto n1 = (unsigned int)(std::sqrt((double)ntot * (double)s1 / (double)s2));
     if (n1 == 0) {
       return { 1, ntot };
@@ -132,11 +130,11 @@ namespace tools {
    * @param s2 Proportion of the second dimension
    * @param s3 Proportion of the third dimension
    */
-  inline auto divideInProportions3D(
-    unsigned int ntot,
-    unsigned int s1,
-    unsigned int s2,
-    unsigned int s3) -> std::tuple<unsigned int, unsigned int, unsigned int> {
+  inline auto divideInProportions3D(unsigned int ntot,
+                                    unsigned int s1,
+                                    unsigned int s2,
+                                    unsigned int s3)
+    -> std::tuple<unsigned int, unsigned int, unsigned int> {
     auto n1 = (unsigned int)(std::cbrt(
       (double)ntot * (double)(SQR(s1)) / (double)(s2 * s3)));
     if (n1 > ntot) {
@@ -165,10 +163,10 @@ namespace tools {
    *
    * @note If decomposition has -1, it will be calculated automatically
    */
-  inline auto Decompose(
-    unsigned int                 ndomains,
-    const std::vector<ncells_t>& ncells,
-    const std::vector<int>& decomposition) -> std::vector<std::vector<ncells_t>> {
+  inline auto Decompose(unsigned int                 ndomains,
+                        const std::vector<ncells_t>& ncells,
+                        const std::vector<int>&      decomposition)
+    -> std::vector<std::vector<ncells_t>> {
     const auto dimension = ncells.size();
     raise::ErrorIf(dimension != decomposition.size(),
                    "Decomposition error: dimension != decomposition.size",

--- a/src/kernels/digital_filter.hpp
+++ b/src/kernels/digital_filter.hpp
@@ -19,35 +19,38 @@
 
 #define FILTER2D_IN_I1(ARR, COMP, I, J)                                        \
   INV_2*(ARR)((I), (J), (COMP)) +                                              \
-    INV_4*((ARR)((I)-1, (J), (COMP)) + (ARR)((I) + 1, (J), (COMP)))
+    INV_4*((ARR)((I) - 1, (J), (COMP)) + (ARR)((I) + 1, (J), (COMP)))
 
 #define FILTER2D_IN_I2(ARR, COMP, I, J)                                        \
   INV_2*(ARR)((I), (J), (COMP)) +                                              \
-    INV_4*((ARR)((I), (J)-1, (COMP)) + (ARR)((I), (J) + 1, (COMP)))
+    INV_4*((ARR)((I), (J) - 1, (COMP)) + (ARR)((I), (J) + 1, (COMP)))
 
-#define FILTER3D_IN_I1_I2(ARR, COMP, I, J, K)                                   \
-  INV_4*(ARR)(I, J, K, (COMP)) +                                                \
-    INV_8*((ARR)((I)-1, (J), (K), (COMP)) + (ARR)((I) + 1, (J), (K), (COMP)) +  \
-           (ARR)((I), (J)-1, (K), (COMP)) + (ARR)((I), (J) + 1, (K), (COMP))) + \
-    INV_16*(                                                                    \
-      (ARR)((I)-1, (J)-1, (K), (COMP)) + (ARR)((I) + 1, (J) + 1, (K), (COMP)) + \
-      (ARR)((I)-1, (J) + 1, (K), (COMP)) + (ARR)((I) + 1, (J)-1, (K), (COMP)))
+#define FILTER3D_IN_I1_I2(ARR, COMP, I, J, K)                                     \
+  INV_4*(ARR)(I, J, K, (COMP)) +                                                  \
+    INV_8*((ARR)((I) - 1, (J), (K), (COMP)) + (ARR)((I) + 1, (J), (K), (COMP)) +  \
+           (ARR)((I), (J) - 1, (K), (COMP)) + (ARR)((I), (J) + 1, (K), (COMP))) + \
+    INV_16*((ARR)((I) - 1, (J) - 1, (K), (COMP)) +                                \
+            (ARR)((I) + 1, (J) + 1, (K), (COMP)) +                                \
+            (ARR)((I) - 1, (J) + 1, (K), (COMP)) +                                \
+            (ARR)((I) + 1, (J) - 1, (K), (COMP)))
 
-#define FILTER3D_IN_I2_I3(ARR, COMP, I, J, K)                                   \
-  INV_4*(ARR)(I, J, K, (COMP)) +                                                \
-    INV_8*((ARR)((I), (J)-1, (K), (COMP)) + (ARR)((I), (J) + 1, (K), (COMP)) +  \
-           (ARR)((I), (J), (K)-1, (COMP)) + (ARR)((I), (J), (K) + 1, (COMP))) + \
-    INV_16*(                                                                    \
-      (ARR)((I), (J)-1, (K)-1, (COMP)) + (ARR)((I), (J) + 1, (K) + 1, (COMP)) + \
-      (ARR)((I), (J)-1, (K) + 1, (COMP)) + (ARR)((I), (J) + 1, (K)-1, (COMP)))
+#define FILTER3D_IN_I2_I3(ARR, COMP, I, J, K)                                     \
+  INV_4*(ARR)(I, J, K, (COMP)) +                                                  \
+    INV_8*((ARR)((I), (J) - 1, (K), (COMP)) + (ARR)((I), (J) + 1, (K), (COMP)) +  \
+           (ARR)((I), (J), (K) - 1, (COMP)) + (ARR)((I), (J), (K) + 1, (COMP))) + \
+    INV_16*((ARR)((I), (J) - 1, (K) - 1, (COMP)) +                                \
+            (ARR)((I), (J) + 1, (K) + 1, (COMP)) +                                \
+            (ARR)((I), (J) - 1, (K) + 1, (COMP)) +                                \
+            (ARR)((I), (J) + 1, (K) - 1, (COMP)))
 
-#define FILTER3D_IN_I1_I3(ARR, COMP, I, J, K)                                   \
-  INV_4*(ARR)(I, J, K, (COMP)) +                                                \
-    INV_8*((ARR)((I)-1, (J), (K), (COMP)) + (ARR)((I) + 1, (J), (K), (COMP)) +  \
-           (ARR)((I), (J), (K)-1, (COMP)) + (ARR)((I), (J), (K) + 1, (COMP))) + \
-    INV_16*(                                                                    \
-      (ARR)((I)-1, (J), (K)-1, (COMP)) + (ARR)((I) + 1, (J), (K) + 1, (COMP)) + \
-      (ARR)((I)-1, (J), (K) + 1, (COMP)) + (ARR)((I) + 1, (J), (K)-1, (COMP)))
+#define FILTER3D_IN_I1_I3(ARR, COMP, I, J, K)                                     \
+  INV_4*(ARR)(I, J, K, (COMP)) +                                                  \
+    INV_8*((ARR)((I) - 1, (J), (K), (COMP)) + (ARR)((I) + 1, (J), (K), (COMP)) +  \
+           (ARR)((I), (J), (K) - 1, (COMP)) + (ARR)((I), (J), (K) + 1, (COMP))) + \
+    INV_16*((ARR)((I) - 1, (J), (K) - 1, (COMP)) +                                \
+            (ARR)((I) + 1, (J), (K) + 1, (COMP)) +                                \
+            (ARR)((I) - 1, (J), (K) + 1, (COMP)) +                                \
+            (ARR)((I) + 1, (J), (K) - 1, (COMP)))
 
 namespace kernel {
   using namespace ntt;

--- a/src/kernels/emission/compton.hpp
+++ b/src/kernels/emission/compton.hpp
@@ -222,9 +222,6 @@ namespace kernel {
             photon_cntr + index);
         }
       }
-
-      static_assert(kernel::traits::emission::IsValid<Compton<M>, M>,
-                    "Compton emission policy is invalid");
     };
 
   } // namespace emission

--- a/src/kernels/emission/compton.hpp
+++ b/src/kernels/emission/compton.hpp
@@ -7,10 +7,12 @@
 #include "metrics/traits.h"
 
 #include "framework/parameters/parameters.h"
-
+#include "kernels/emission/traits.h"
 #include "kernels/injectors.hpp"
 
 #include <Kokkos_Pair.hpp>
+
+#include <vector>
 
 namespace kernel {
   namespace emission {
@@ -24,9 +26,10 @@ namespace kernel {
         real_t photon_energy;
       };
 
-      const real_t species_mass;
-      const real_t emitted_photon_weight;
-      const real_t emitted_photon_min_energy;
+      const spidx_t emitted_index;
+      const real_t  species_mass;
+      const real_t  emitted_photon_weight;
+      const real_t  emitted_photon_min_energy;
 
       const real_t nominal_probability;
       const real_t nominal_photon_energy;
@@ -48,6 +51,7 @@ namespace kernel {
       random_number_pool_t random_pool;
 
       Compton(Particles<M::Dim, M::CoordType>& photon_species,
+              spidx_t                          emitted_index,
               float                            sp_mass,
               float                            sp_charge,
               RadiativeDragFlags               radiative_drag_flags,
@@ -55,7 +59,8 @@ namespace kernel {
               npart_t                          domain_idx,
               const SimulationParams&          params,
               random_number_pool_t&            random_pool)
-        : species_mass { static_cast<real_t>(sp_mass) }
+        : emitted_index { emitted_index }
+        , species_mass { static_cast<real_t>(sp_mass) }
         , emitted_photon_weight { params.template get<real_t>(
             "radiation.emission.compton.photon_weight") }
         , emitted_photon_min_energy { params.template get<real_t>(
@@ -88,10 +93,14 @@ namespace kernel {
         , photon_use_tracking { photon_species.use_tracking() }
         , random_pool { random_pool } {}
 
-      auto number_injected() const -> npart_t {
+      auto emitted_species_indices() const -> std::vector<spidx_t> {
+        return { emitted_index };
+      }
+
+      auto numbers_injected() const -> std::vector<npart_t> {
         auto photon_idx_h = Kokkos::create_mirror_view(photon_idx);
         Kokkos::deep_copy(photon_idx_h, photon_idx);
-        return photon_idx_h();
+        return { photon_idx_h() };
       }
 
       /**
@@ -214,6 +223,9 @@ namespace kernel {
             photon_cntr + index);
         }
       }
+
+      static_assert(kernel::traits::emission::IsValid<Compton<M>, M>,
+                    "Compton emission policy is invalid");
     };
 
   } // namespace emission

--- a/src/kernels/emission/compton.hpp
+++ b/src/kernels/emission/compton.hpp
@@ -55,7 +55,6 @@ namespace kernel {
               float                            sp_mass,
               float                            sp_charge,
               RadiativeDragFlags               radiative_drag_flags,
-              real_t                           dt,
               npart_t                          domain_idx,
               const SimulationParams&          params,
               random_number_pool_t&            random_pool)

--- a/src/kernels/emission/synchrotron.hpp
+++ b/src/kernels/emission/synchrotron.hpp
@@ -7,10 +7,12 @@
 #include "metrics/traits.h"
 
 #include "framework/parameters/parameters.h"
-
+#include "kernels/emission/traits.h"
 #include "kernels/injectors.hpp"
 
 #include <Kokkos_Pair.hpp>
+
+#include <vector>
 
 namespace kernel {
   namespace emission {
@@ -24,9 +26,10 @@ namespace kernel {
         real_t photon_energy;
       };
 
-      const real_t species_mass;
-      const real_t emitted_photon_weight;
-      const real_t emitted_photon_min_energy;
+      const spidx_t emitted_index;
+      const real_t  species_mass;
+      const real_t  emitted_photon_weight;
+      const real_t  emitted_photon_min_energy;
 
       const real_t nominal_probability;
       const real_t nominal_photon_energy;
@@ -48,6 +51,7 @@ namespace kernel {
       random_number_pool_t random_pool;
 
       Synchrotron(Particles<M::Dim, M::CoordType>& photon_species,
+                  spidx_t                          emitted_index,
                   float                            sp_mass,
                   float                            sp_charge,
                   RadiativeDragFlags               radiative_drag_flags,
@@ -55,7 +59,8 @@ namespace kernel {
                   npart_t                          domain_idx,
                   const SimulationParams&          params,
                   random_number_pool_t&            random_pool)
-        : species_mass { static_cast<real_t>(sp_mass) }
+        : emitted_index { emitted_index }
+        , species_mass { static_cast<real_t>(sp_mass) }
         , emitted_photon_weight { params.template get<real_t>(
             "radiation.emission.synchrotron.photon_weight") }
         , emitted_photon_min_energy { params.template get<real_t>(
@@ -89,10 +94,14 @@ namespace kernel {
         , photon_use_tracking { photon_species.use_tracking() }
         , random_pool { random_pool } {}
 
-      auto number_injected() const -> npart_t {
+      auto emitted_species_indices() const -> std::vector<spidx_t> {
+        return { emitted_index };
+      }
+
+      auto numbers_injected() const -> std::vector<npart_t> {
         auto photon_idx_h = Kokkos::create_mirror_view(photon_idx);
         Kokkos::deep_copy(photon_idx_h, photon_idx);
-        return photon_idx_h();
+        return { photon_idx_h() };
       }
 
       /**
@@ -266,6 +275,9 @@ namespace kernel {
             photon_cntr + index);
         }
       }
+
+      static_assert(kernel::traits::emission::IsValid<Synchrotron<M>, M>,
+                    "Synchrotron emission policy is invalid");
     };
 
   } // namespace emission

--- a/src/kernels/emission/synchrotron.hpp
+++ b/src/kernels/emission/synchrotron.hpp
@@ -274,9 +274,6 @@ namespace kernel {
             photon_cntr + index);
         }
       }
-
-      static_assert(kernel::traits::emission::IsValid<Synchrotron<M>, M>,
-                    "Synchrotron emission policy is invalid");
     };
 
   } // namespace emission

--- a/src/kernels/emission/synchrotron.hpp
+++ b/src/kernels/emission/synchrotron.hpp
@@ -55,7 +55,6 @@ namespace kernel {
                   float                            sp_mass,
                   float                            sp_charge,
                   RadiativeDragFlags               radiative_drag_flags,
-                  real_t                           dt,
                   npart_t                          domain_idx,
                   const SimulationParams&          params,
                   random_number_pool_t&            random_pool)

--- a/src/kernels/emission/traits.h
+++ b/src/kernels/emission/traits.h
@@ -1,0 +1,75 @@
+/**
+ * @file kernels/emission/traits.h
+ * @brief Concepts and traits for emission policies
+ * @implements
+ *   - kernel::traits::emission::HasPayload
+ * @namespaces:
+ *   - kernel::traits::emission::
+ */
+
+#ifndef KERNELS_EMISSION_TRAITS_H
+#define KERNELS_EMISSION_TRAITS_H
+
+#include "global.h"
+
+#include <Kokkos_Pair.hpp>
+
+#include <vector>
+
+namespace kernel {
+  namespace traits {
+    namespace emission {
+      template <class E>
+      concept HasPayload = requires { typename E::Payload; };
+
+      template <class E>
+      concept HasNumbersInjected = requires(E& emission_policy) {
+        {
+          emission_policy.numbers_injected()
+        } -> std::convertible_to<std::vector<npart_t>>;
+      };
+
+      template <class E>
+      concept HasEmittedSpeciesIndices = requires(const E& emission_policy) {
+        {
+          emission_policy.emitted_species_indices()
+        } -> std::convertible_to<std::vector<spidx_t>>;
+      };
+
+      template <class E, class M>
+      concept HasShouldEmit = requires(const E& emission_policy,
+                                       const coord_t<M::PrtlDim>& x_Cd,
+                                       const coord_t<M::PrtlDim>& x_Ph,
+                                       const vec_t<Dim::_3D>&     u_Ph,
+                                       const vec_t<Dim::_3D>&     ep_Ph,
+                                       const vec_t<Dim::_3D>&     bp_Ph,
+                                       vec_t<Dim::_3D>&           delta_u_Ph,
+                                       typename E::Payload&       payload) {
+        {
+          emission_policy.shouldEmit(x_Cd, x_Ph, u_Ph, ep_Ph, bp_Ph, delta_u_Ph, payload)
+        } -> std::convertible_to<Kokkos::pair<bool, bool>>;
+      };
+
+      template <class E, class M>
+      concept HasEmit = requires(const E&                    emission_policy,
+                                 const tuple_t<int, M::Dim>& xi_Cd,
+                                 const tuple_t<prtldx_t, M::Dim>& dxi_Cd,
+                                 const vec_t<Dim::_3D>&           direction,
+                                 real_t                           weight,
+                                 real_t                           phi,
+                                 const typename E::Payload&       payload) {
+        {
+          emission_policy.emit(xi_Cd, dxi_Cd, direction, weight, phi, payload)
+        } -> std::same_as<void>;
+      };
+
+      template <class E, class M>
+      concept IsValid = HasPayload<E> && HasNumbersInjected<E> &&
+                        HasEmittedSpeciesIndices<E> && HasShouldEmit<E, M> &&
+                        HasEmit<E, M>;
+
+    } // namespace emission
+  } // namespace traits
+} // namespace kernel
+
+#endif // KERNELS_EMISSION_TRAITS_H

--- a/src/kernels/fields_bcs.hpp
+++ b/src/kernels/fields_bcs.hpp
@@ -20,7 +20,6 @@
 #include "global.h"
 
 #include "arch/kokkos_aliases.h"
-#include "arch/traits.h"
 #include "utils/error.h"
 #include "utils/numeric.h"
 
@@ -42,42 +41,27 @@ namespace kernel::bc {
   template <SimEngine::type S, class I, class M, in o>
     requires metric::traits::HasD<M> && metric::traits::HasConvert_i<M> &&
              metric::traits::HasConvert<M> &&
-             ((S == SimEngine::SRPIC && metric::traits::HasTransform_i<M>) ||
-              S == SimEngine::GRPIC) &&
-             (S == SimEngine::SRPIC &&
-                (::traits::fieldsetter::HasEx1<I, M::Dim> ||
-                 ::traits::fieldsetter::HasEx2<I, M::Dim> ||
-                 ::traits::fieldsetter::HasEx3<I, M::Dim> ||
+             (((S == SimEngine::SRPIC) && metric::traits::HasTransform_i<M>) ||
+              (S == SimEngine::GRPIC)) &&
+             (((S == SimEngine::SRPIC) &&
+               (::traits::fieldsetter::HasEx1<I, M::Dim> ||
+                ::traits::fieldsetter::HasEx2<I, M::Dim> ||
+                ::traits::fieldsetter::HasEx3<I, M::Dim> ||
+                ::traits::fieldsetter::HasBx1<I, M::Dim> ||
+                ::traits::fieldsetter::HasBx2<I, M::Dim> ||
+                ::traits::fieldsetter::HasBx3<I, M::Dim>)) ||
+              (((S == SimEngine::GRPIC) &&
+                (::traits::fieldsetter::HasDx1<I, M::Dim> ||
+                 ::traits::fieldsetter::HasDx2<I, M::Dim> ||
+                 ::traits::fieldsetter::HasDx3<I, M::Dim> ||
                  ::traits::fieldsetter::HasBx1<I, M::Dim> ||
                  ::traits::fieldsetter::HasBx2<I, M::Dim> ||
-                 ::traits::fieldsetter::HasBx3<I, M::Dim>) ||
-              (S == SimEngine::GRPIC &&
-                 (::traits::fieldsetter::HasDx1<I, M::Dim> ||
-                  ::traits::fieldsetter::HasDx2<I, M::Dim> ||
-                  ::traits::fieldsetter::HasDx3<I, M::Dim>) ||
-               ::traits::fieldsetter::HasBx1<I, M::Dim> ||
-               ::traits::fieldsetter::HasBx2<I, M::Dim> ||
-               ::traits::fieldsetter::HasBx3<I, M::Dim>))
+                 ::traits::fieldsetter::HasBx3<I, M::Dim>))))
   struct MatchBoundaries_kernel {
     static_assert(static_cast<dim_t>(o) < static_cast<dim_t>(M::Dim),
                   "Invalid component index");
     static constexpr auto  D = M::Dim;
     static constexpr idx_t i = static_cast<idx_t>(o) + 1u;
-    // static constexpr bool defines_dx1 = traits::has_method<traits::dx1_t, I>::value;
-    // static constexpr bool defines_dx2 = traits::has_method<traits::dx2_t, I>::value;
-    // static constexpr bool defines_dx3 = traits::has_method<traits::dx3_t, I>::value;
-    // static constexpr bool defines_ex1 = traits::has_method<traits::ex1_t, I>::value;
-    // static constexpr bool defines_ex2 = traits::has_method<traits::ex2_t, I>::value;
-    // static constexpr bool defines_ex3 = traits::has_method<traits::ex3_t, I>::value;
-    // static constexpr bool defines_bx1 = traits::has_method<traits::bx1_t, I>::value;
-    // static constexpr bool defines_bx2 = traits::has_method<traits::bx2_t, I>::value;
-    // static constexpr bool defines_bx3 = traits::has_method<traits::bx3_t, I>::value;
-    // static_assert(
-    //   (S == SimEngine::SRPIC and (defines_ex1 or defines_ex2 or defines_ex3 or
-    //                               defines_bx1 or defines_bx2 or defines_bx3)) or
-    //     ((S == SimEngine::GRPIC) and (defines_dx1 or defines_dx2 or defines_dx3 or
-    //                                   defines_bx1 or defines_bx2 or defines_bx3)),
-    //   "none of the components of E/D or B are specified in PGEN");
 
     ndfield_t<M::Dim, 6> Fld;
     const I              fset;

--- a/src/kernels/injectors.hpp
+++ b/src/kernels/injectors.hpp
@@ -72,7 +72,9 @@ namespace kernel {
     weight_arr(p) = weight;
     if constexpr (T) {
       pld_i_arr(p, pldi::spcCtr) = species_cntr;
-#if defined(MPI_ENABLED)
+#if !defined(MPI_ENABLED)
+      (void)domain_idx;
+#else
       pld_i_arr(p, pldi::domIdx) = domain_idx;
 #endif
     }

--- a/src/kernels/particle_pusher_sr.hpp
+++ b/src/kernels/particle_pusher_sr.hpp
@@ -31,6 +31,8 @@
 #include "metrics/traits.h"
 
 #include "kernels/emission/emission.hpp"
+#include "kernels/emission/traits.h"
+
 #include "particle_shapes.hpp"
 
 #if defined(MPI_ENABLED)
@@ -61,6 +63,8 @@ namespace kernel::sr {
   struct NoField_t {};
 
   struct PusherParams {
+    // species index
+    spidx_t             species_index;
     // pusher algorithm(s) assigned to the species
     ParticlePusherFlags pusher_flags { ParticlePusher::NONE };
     // radiative drag force(s) enabled for the species
@@ -110,10 +114,9 @@ namespace kernel::sr {
     static constexpr auto HasExtForce  = ::traits::external::HasExternalF<F, D>;
     static constexpr auto HasExtEfield = ::traits::external::HasExternalE<F, D>;
     static constexpr auto HasExtBfield = ::traits::external::HasExternalB<F, D>;
-    static constexpr auto HasEmission =
-      ::traits::emission::IsValidEmissionPolicy<E, M::PrtlDim>;
+    static constexpr auto HasEmission = kernel::traits::emission::IsValid<E, M>;
     static_assert(
-      ::traits::emission::IsValidEmissionPolicy<E, M::PrtlDim> or
+      HasEmission or
         std::is_same<E, const NoEmissionPolicy_t<SimEngine::SRPIC, M>>::value,
       "Invalid emission policy E for Pusher_kernel");
 
@@ -295,9 +298,45 @@ namespace kernel::sr {
       coord_t<M::PrtlDim> xp_Cd { ZERO };
       getParticlePosition(p, xp_Cd);
       if (pusher_flags == ParticlePusher::PHOTON) {
-        // just update the position
+        /**
+         * Procedure for massless particles
+         */
+        if constexpr (HasEmission) {
+          // get Cartesian position
+          coord_t<M::PrtlDim> xp_Ph { ZERO };
+          if constexpr (M::PrtlDim == Dim::_1D or M::PrtlDim == Dim::_2D or
+                        M::PrtlDim == Dim::_3D) {
+            xp_Ph[0] = metric.template convert<1, Crd::Cd, Crd::Ph>(xp_Cd[0]);
+          }
+          if constexpr (M::PrtlDim == Dim::_2D or M::PrtlDim == Dim::_3D) {
+            xp_Ph[1] = metric.template convert<2, Crd::Cd, Crd::Ph>(xp_Cd[1]);
+          }
+          if constexpr (M::PrtlDim == Dim::_3D) {
+            xp_Ph[2] = metric.template convert<3, Crd::Cd, Crd::Ph>(xp_Cd[2]);
+          }
+
+          // get Cartesian velocity
+          vec_t<Dim::_3D> u_prime { ZERO };
+          u_prime[0] = ux1(p);
+          u_prime[1] = ux2(p);
+          u_prime[2] = ux3(p);
+
+          // get Cartesian fields
+          vec_t<Dim::_3D> ei { ZERO }, bi { ZERO };
+          vec_t<Dim::_3D> ei_Cart { ZERO }, bi_Cart { ZERO };
+          getInterpolatedEMFields<SHAPE_ORDER>(p, ei, bi);
+
+          metric.template transform_xyz<Idx::U, Idx::XYZ>(xp_Cd, ei, ei_Cart);
+          metric.template transform_xyz<Idx::U, Idx::XYZ>(xp_Cd, bi, bi_Cart);
+
+          processEmission(p, u_prime, xp_Cd, xp_Ph, ei_Cart, bi_Cart);
+        }
+        // finally update the position
         positionPush(false, p, xp_Cd);
       } else {
+        /**
+         * Procedure for massive particles
+         */
         // update cartesian velocity
         vec_t<Dim::_3D> ei { ZERO }, bi { ZERO };
         vec_t<Dim::_3D> ei_Cart { ZERO }, bi_Cart { ZERO };
@@ -1487,7 +1526,7 @@ namespace kernel::sr {
                                 const coord_t<M::PrtlDim>& xp_Ph,
                                 const vec_t<Dim::_3D>&     ep_Cart,
                                 const vec_t<Dim::_3D>&     bp_Cart) const
-      requires ::traits::emission::IsValidEmissionPolicy<E, M::PrtlDim>
+      requires kernel::traits::emission::IsValid<E, M>
     {
       typename E::Payload payload;
       vec_t<Dim::_3D>     delta_u_Ph { ZERO };

--- a/src/kernels/prtls_to_phys.hpp
+++ b/src/kernels/prtls_to_phys.hpp
@@ -29,8 +29,8 @@ namespace kernel {
 
   template <SimEngine::type S, class M, bool T>
     requires metric::traits::HasD<M> && metric::traits::HasConvert_i<M> &&
-             ((S == SimEngine::SRPIC && metric::traits::HasTransformXYZ<M>) ||
-              S == SimEngine::GRPIC && metric::traits::HasTransform<M>)
+             (((S == SimEngine::SRPIC) && metric::traits::HasTransformXYZ<M>) ||
+              ((S == SimEngine::GRPIC) && metric::traits::HasTransform<M>))
   class PrtlToPhys_kernel {
     static constexpr Dimension D = M::Dim;
 

--- a/src/kernels/reduced_stats.hpp
+++ b/src/kernels/reduced_stats.hpp
@@ -24,9 +24,9 @@ namespace kernel {
 
   template <SimEngine::type S, class M, StatsID::type F, unsigned short I = 0>
     requires metric::traits::HasD<M> &&
-             (metric::traits::HasTransform_i<M> || I == 0) &&
-             metric::traits::HasTransform<M> &&
-             metric::traits::HasSqrtDetH<M> && (I <= 3)
+             (metric::traits::HasTransform_i<M> || (I == 0)) &&
+             metric::traits::HasTransform<M> && metric::traits::HasSqrtDetH<M> &&
+             (I <= 3)
   class ReducedFields_kernel {
     static constexpr auto D = M::Dim;
 
@@ -402,8 +402,8 @@ namespace kernel {
 
   template <SimEngine::type S, class M, StatsID::type P>
     requires metric::traits::HasD<M> &&
-             ((S == SimEngine::SRPIC && metric::traits::HasTransformXYZ<M>) ||
-              S == SimEngine::GRPIC && metric::traits::HasTransform<M>) &&
+             (((S == SimEngine::SRPIC) && metric::traits::HasTransformXYZ<M>) ||
+              ((S == SimEngine::GRPIC) && metric::traits::HasTransform<M>)) &&
              ((P == StatsID::Rho) || (P == StatsID::Charge) ||
               (P == StatsID::N) || (P == StatsID::Npart) || (P == StatsID::T))
   class ReducedParticleMoments_kernel {

--- a/src/kernels/reduced_stats.hpp
+++ b/src/kernels/reduced_stats.hpp
@@ -25,8 +25,8 @@ namespace kernel {
   template <SimEngine::type S, class M, StatsID::type F, unsigned short I = 0>
     requires metric::traits::HasD<M> &&
              (metric::traits::HasTransform_i<M> || I == 0) &&
-             metric::traits::HasTransform<M> && metric::traits::HasSqrtDetH<M> &&
-             (I <= 3)
+             metric::traits::HasTransform<M> &&
+             metric::traits::HasSqrtDetH<M> && (I <= 3)
   class ReducedFields_kernel {
     static constexpr auto D = M::Dim;
 

--- a/src/kernels/tests/CMakeLists.txt
+++ b/src/kernels/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ function(gen_test title)
   set(src ${title}.cpp)
   add_executable(${exec} ${src})
 
-  set(libs ntt_kernels ntt_metrics)
+  set(libs ntt_kernels ntt_metrics ntt_framework)
   add_dependencies(${exec} ${libs})
   target_link_libraries(${exec} PRIVATE ${libs})
 
@@ -36,3 +36,4 @@ gen_test(flds_bc)
 gen_test(pusher)
 gen_test(ext_force)
 gen_test(reduced_stats)
+gen_test(custom_emission)

--- a/src/kernels/tests/custom_emission.cpp
+++ b/src/kernels/tests/custom_emission.cpp
@@ -1,0 +1,343 @@
+#include "global.h"
+
+#include "arch/kokkos_aliases.h"
+
+#include "metrics/minkowski.h"
+
+#include "framework/containers/particles.h"
+#include "kernels/injectors.hpp"
+#include "kernels/particle_pusher_sr.hpp"
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Pair.hpp>
+
+#include <iostream>
+#include <vector>
+
+template <class M>
+struct EmissionPolicy {
+  struct Payload {};
+
+  array_t<npart_t> sp1_idx { "sp1_idx" };
+  array_t<npart_t> sp2_idx { "sp2_idx" };
+
+  const unsigned int step;
+
+  const npart_t sp1_offset, sp2_offset;
+
+  array_t<int*>      sp1_i1, sp1_i2, sp1_i3;
+  array_t<prtldx_t*> sp1_dx1, sp1_dx2, sp1_dx3;
+  array_t<real_t*>   sp1_ux1, sp1_ux2, sp1_ux3;
+  array_t<real_t*>   sp1_phi;
+  array_t<real_t*>   sp1_weight;
+  array_t<short*>    sp1_tag;
+  array_t<npart_t**> sp1_pld_i;
+
+  array_t<int*>      sp2_i1, sp2_i2, sp2_i3;
+  array_t<prtldx_t*> sp2_dx1, sp2_dx2, sp2_dx3;
+  array_t<real_t*>   sp2_ux1, sp2_ux2, sp2_ux3;
+  array_t<real_t*>   sp2_phi;
+  array_t<real_t*>   sp2_weight;
+  array_t<short*>    sp2_tag;
+  array_t<npart_t**> sp2_pld_i;
+
+  EmissionPolicy(unsigned int        step,
+                 npart_t             sp1_offset,
+                 array_t<int*>&      sp1_i1,
+                 array_t<int*>&      sp1_i2,
+                 array_t<int*>&      sp1_i3,
+                 array_t<prtldx_t*>& sp1_dx1,
+                 array_t<prtldx_t*>& sp1_dx2,
+                 array_t<prtldx_t*>& sp1_dx3,
+                 array_t<real_t*>&   sp1_ux1,
+                 array_t<real_t*>&   sp1_ux2,
+                 array_t<real_t*>&   sp1_ux3,
+                 array_t<real_t*>&   sp1_phi,
+                 array_t<real_t*>&   sp1_weight,
+                 array_t<short*>&    sp1_tag,
+                 array_t<npart_t**>& sp1_pld_i,
+                 npart_t             sp2_offset,
+                 array_t<int*>&      sp2_i1,
+                 array_t<int*>&      sp2_i2,
+                 array_t<int*>&      sp2_i3,
+                 array_t<prtldx_t*>& sp2_dx1,
+                 array_t<prtldx_t*>& sp2_dx2,
+                 array_t<prtldx_t*>& sp2_dx3,
+                 array_t<real_t*>&   sp2_ux1,
+                 array_t<real_t*>&   sp2_ux2,
+                 array_t<real_t*>&   sp2_ux3,
+                 array_t<real_t*>&   sp2_phi,
+                 array_t<real_t*>&   sp2_weight,
+                 array_t<short*>&    sp2_tag,
+                 array_t<npart_t**>& sp2_pld_i)
+    : step { step }
+    , sp1_offset { sp1_offset }
+    , sp1_i1 { sp1_i1 }
+    , sp1_i2 { sp1_i2 }
+    , sp1_i3 { sp1_i3 }
+    , sp1_dx1 { sp1_dx1 }
+    , sp1_dx2 { sp1_dx2 }
+    , sp1_dx3 { sp1_dx3 }
+    , sp1_ux1 { sp1_ux1 }
+    , sp1_ux2 { sp1_ux2 }
+    , sp1_ux3 { sp1_ux3 }
+    , sp1_phi { sp1_phi }
+    , sp1_weight { sp1_weight }
+    , sp1_tag { sp1_tag }
+    , sp1_pld_i { sp1_pld_i }
+    , sp2_offset { sp2_offset }
+    , sp2_i1 { sp2_i1 }
+    , sp2_i2 { sp2_i2 }
+    , sp2_i3 { sp2_i3 }
+    , sp2_dx1 { sp2_dx1 }
+    , sp2_dx2 { sp2_dx2 }
+    , sp2_dx3 { sp2_dx3 }
+    , sp2_ux1 { sp2_ux1 }
+    , sp2_ux2 { sp2_ux2 }
+    , sp2_ux3 { sp2_ux3 }
+    , sp2_phi { sp2_phi }
+    , sp2_weight { sp2_weight }
+    , sp2_tag { sp2_tag }
+    , sp2_pld_i { sp2_pld_i } {}
+
+  Inline auto shouldEmit(const coord_t<M::PrtlDim>& x_Cd,
+                         const coord_t<M::PrtlDim>& x_Ph,
+                         const vec_t<Dim::_3D>&     u_Ph,
+                         const vec_t<Dim::_3D>&,
+                         const vec_t<Dim::_3D>&,
+                         vec_t<Dim::_3D>& delta_u_Ph,
+                         Payload& payload) const -> Kokkos::pair<bool, bool> {
+    delta_u_Ph[0] = -TWO;
+    delta_u_Ph[1] = ZERO;
+    delta_u_Ph[2] = ZERO;
+    return { true, false };
+  }
+
+  Inline auto emit(const tuple_t<int, M::Dim>&      xi_Cd,
+                   const tuple_t<prtldx_t, M::Dim>& dxi_Cd,
+                   const vec_t<Dim::_3D>&           direction,
+                   real_t,
+                   real_t,
+                   const Payload&) const -> void {
+    if (step % 2u == 0u) {
+      const auto sp1_inj_index = Kokkos::atomic_fetch_add(&sp1_idx(), 1);
+      kernel::InjectParticle<M::Dim, M::CoordType, false>(
+        sp1_offset + sp1_inj_index,
+        sp1_i1,
+        sp1_i2,
+        sp1_i3,
+        sp1_dx1,
+        sp1_dx2,
+        sp1_dx3,
+        sp1_ux1,
+        sp1_ux2,
+        sp1_ux3,
+        sp1_phi,
+        sp1_weight,
+        sp1_tag,
+        sp1_pld_i,
+        xi_Cd,
+        dxi_Cd,
+        { direction[0], direction[1], direction[2] });
+    } else if (step != 3u) {
+      const auto sp2_inj_index = Kokkos::atomic_fetch_add(&sp2_idx(), 1);
+      kernel::InjectParticle<M::Dim, M::CoordType, false>(
+        sp2_offset + sp2_inj_index,
+        sp2_i1,
+        sp2_i2,
+        sp2_i3,
+        sp2_dx1,
+        sp2_dx2,
+        sp2_dx3,
+        sp2_ux1,
+        sp2_ux2,
+        sp2_ux3,
+        sp2_phi,
+        sp2_weight,
+        sp2_tag,
+        sp2_pld_i,
+        xi_Cd,
+        dxi_Cd,
+        { HALF * direction[0], HALF * direction[1], HALF * direction[2] });
+    }
+  }
+
+  auto emitted_species_indices() const -> std::vector<spidx_t> {
+    return { 2u, 3u };
+  }
+
+  auto numbers_injected() const -> std::vector<npart_t> {
+    auto sp1_idx_h = Kokkos::create_mirror_view(sp1_idx);
+    Kokkos::deep_copy(sp1_idx_h, sp1_idx);
+    auto sp2_idx_h = Kokkos::create_mirror_view(sp2_idx);
+    Kokkos::deep_copy(sp2_idx_h, sp2_idx);
+    return { sp1_idx_h(), sp2_idx_h() };
+  }
+};
+
+auto main(int argc, char* argv[]) -> int {
+  ntt::GlobalInitialize(argc, argv);
+
+  try {
+    using namespace ntt;
+    metric::Minkowski<Dim::_1D> metric { { 128u }, { { 0.0, 1.0 } }, {} };
+
+    const auto delta_t = metric.dxMin() * 0.5;
+    auto emitting_species = Particles<decltype(metric)::Dim, decltype(metric)::CoordType>(
+      1,
+      "emitter",
+      0.0f,
+      0.0f,
+      100u,
+      0u,
+      0u,
+      ParticlePusher::PHOTON,
+      false,
+      RadiativeDrag::NONE,
+      EmissionType::CUSTOM,
+      0u,
+      0u);
+    auto emitting_tag_h = Kokkos::create_mirror_view(emitting_species.tag);
+    emitting_tag_h(0)   = ParticleTag::alive;
+    emitting_tag_h(1)   = ParticleTag::alive;
+    Kokkos::deep_copy(emitting_species.tag, emitting_tag_h);
+
+    auto emitted_species_1 = Particles<decltype(metric)::Dim, decltype(metric)::CoordType>(
+      2,
+      "emitted_1",
+      1.0f,
+      1.0f,
+      100u,
+      0u,
+      0u,
+      ParticlePusher::BORIS,
+      false,
+      RadiativeDrag::NONE,
+      EmissionType::NONE,
+      0u,
+      0u);
+    auto emitted_species_2 = Particles<decltype(metric)::Dim, decltype(metric)::CoordType>(
+      3,
+      "emitted_2",
+      1.0f,
+      -1.0f,
+      100u,
+      0u,
+      0u,
+      ParticlePusher::BORIS,
+      false,
+      RadiativeDrag::NONE,
+      EmissionType::NONE,
+      0u,
+      0u);
+
+    auto pusher_arrays = emitting_species.PusherKernelArrays();
+
+    kernel::sr::PusherParams pusher_params {};
+    pusher_params.pusher_flags = emitting_species.pusher();
+    pusher_params.radiative_drag_flags = emitting_species.radiative_drag_flags();
+    pusher_params.mass       = emitting_species.mass();
+    pusher_params.charge     = emitting_species.charge();
+    pusher_params.dt         = delta_t;
+    pusher_params.omegaB0    = 1.0f;
+    pusher_params.ni1        = 128u;
+    pusher_params.ni2        = 1u;
+    pusher_params.ni3        = 1u;
+    pusher_params.boundaries = {
+      { PrtlBC::PERIODIC, PrtlBC::PERIODIC }
+    };
+
+    ndfield_t<Dim::_1D, 6> EB { "EB", 128u + 2u * N_GHOSTS };
+
+    for (auto step = 0u; step < 7u; ++step) {
+      pusher_params.time   = static_cast<simtime_t>(step) * delta_t;
+      auto emission_policy = EmissionPolicy<decltype(metric)> {
+        step,
+        emitted_species_1.npart(),
+        emitted_species_1.i1,
+        emitted_species_1.i2,
+        emitted_species_1.i3,
+        emitted_species_1.dx1,
+        emitted_species_1.dx2,
+        emitted_species_1.dx3,
+        emitted_species_1.ux1,
+        emitted_species_1.ux2,
+        emitted_species_1.ux3,
+        emitted_species_1.phi,
+        emitted_species_1.weight,
+        emitted_species_1.tag,
+        emitted_species_1.pld_i,
+        emitted_species_2.npart(),
+        emitted_species_2.i1,
+        emitted_species_2.i2,
+        emitted_species_2.i3,
+        emitted_species_2.dx1,
+        emitted_species_2.dx2,
+        emitted_species_2.dx3,
+        emitted_species_2.ux1,
+        emitted_species_2.ux2,
+        emitted_species_2.ux3,
+        emitted_species_2.phi,
+        emitted_species_2.weight,
+        emitted_species_2.tag,
+        emitted_species_2.pld_i
+      };
+
+      Kokkos::parallel_for(
+        "ParticlePusher",
+        2u,
+        kernel::sr::Pusher_kernel<decltype(metric), kernel::sr::NoField_t, false, decltype(emission_policy)>(
+          pusher_params,
+          pusher_arrays,
+          EB,
+          metric,
+          kernel::sr::NoField_t {},
+          emission_policy));
+      const auto n_injected = emission_policy.numbers_injected();
+      emitted_species_1.set_counter(emitted_species_1.counter() + n_injected[0]);
+      emitted_species_1.set_npart(emitted_species_1.npart() + n_injected[0]);
+      emitted_species_2.set_counter(emitted_species_2.counter() + n_injected[1]);
+      emitted_species_2.set_npart(emitted_species_2.npart() + n_injected[1]);
+    }
+    raise::ErrorIf(emitted_species_1.npart() != 8u,
+                   "Unexpected number of particles for emitted species 1",
+                   HERE);
+    raise::ErrorIf(emitted_species_2.npart() != 4u,
+                   "Unexpected number of particles for emitted species 2",
+                   HERE);
+
+    auto sp1_tag_h = Kokkos::create_mirror_view(emitted_species_1.tag);
+    Kokkos::deep_copy(sp1_tag_h, emitted_species_1.tag);
+    auto sp1_ux1_h = Kokkos::create_mirror_view(emitted_species_1.ux1);
+    Kokkos::deep_copy(sp1_ux1_h, emitted_species_1.ux1);
+
+    auto sp2_tag_h = Kokkos::create_mirror_view(emitted_species_2.tag);
+    Kokkos::deep_copy(sp2_tag_h, emitted_species_2.tag);
+    auto sp2_ux1_h = Kokkos::create_mirror_view(emitted_species_2.ux1);
+    Kokkos::deep_copy(sp2_ux1_h, emitted_species_2.ux1);
+
+    for (auto i = 0u; i < emitted_species_1.npart(); ++i) {
+      raise::ErrorIf(sp1_tag_h(i) != ParticleTag::alive,
+                     "Unexpected tag value for emitted species 1",
+                     HERE);
+      raise::ErrorIf(sp1_ux1_h(i) != ONE,
+                     "Unexpected ux1 value for emitted species 1",
+                     HERE);
+    }
+    for (auto i = 0u; i < emitted_species_2.npart(); ++i) {
+      raise::ErrorIf(sp2_tag_h(i) != ParticleTag::alive,
+                     "Unexpected tag value for emitted species 1",
+                     HERE);
+      raise::ErrorIf(sp2_ux1_h(i) != HALF,
+                     "Unexpected ux1 value for emitted species 1",
+                     HERE);
+    }
+
+  } catch (std::exception& e) {
+    std::cerr << e.what() << std::endl;
+    ntt::GlobalFinalize();
+    return 1;
+  }
+  ntt::GlobalFinalize();
+  return 0;
+}

--- a/src/kernels/tests/deposit.cpp
+++ b/src/kernels/tests/deposit.cpp
@@ -142,7 +142,7 @@ void testDeposit(const std::vector<std::size_t>&      res,
   put_value<real_t>(ux3, uz, 0);
   put_value<real_t>(weight, 1.0, 0);
   put_value<short>(tag, ParticleTag::alive, 0);
-  
+
   auto J_scat = Kokkos::Experimental::create_scatter_view(J);
 
   // clang-format off

--- a/src/metrics/kerr_schild.h
+++ b/src/metrics/kerr_schild.h
@@ -450,15 +450,15 @@ namespace metric {
     Inline auto polar_area(real_t x1) const -> real_t {
       if (small_angle) {
         return dr * (SQR(x1 * dr + x1_min) + SQR(a)) *
-              math::sqrt(ONE + TWO * (x1 * dr + x1_min) /
+               math::sqrt(ONE + TWO * (x1 * dr + x1_min) /
                                   (SQR(x1 * dr + x1_min) + SQR(a))) *
                (static_cast<real_t>(48) - SQR(dtheta)) * SQR(dtheta) /
                static_cast<real_t>(384);
       } else {
         return dr * (SQR(x1 * dr + x1_min) + SQR(a)) *
-              math::sqrt(ONE + TWO * (x1 * dr + x1_min) /
+               math::sqrt(ONE + TWO * (x1 * dr + x1_min) /
                                   (SQR(x1 * dr + x1_min) + SQR(a))) *
-              (ONE - math::cos(HALF * dtheta));
+               (ONE - math::cos(HALF * dtheta));
       }
     }
 

--- a/src/metrics/kerr_schild_0.h
+++ b/src/metrics/kerr_schild_0.h
@@ -189,7 +189,7 @@ namespace metric {
      * dr derivative of lapse function
      * @param x coordinate array in code units
      */
-    Inline auto dr_alpha(const coord_t<D>& x) const -> real_t {
+    Inline auto dr_alpha(const coord_t<D>&) const -> real_t {
       return ZERO;
     }
 
@@ -197,7 +197,7 @@ namespace metric {
      * dtheta derivative of lapse function
      * @param x coordinate array in code units
      */
-    Inline auto dt_alpha(const coord_t<D>& x) const -> real_t {
+    Inline auto dt_alpha(const coord_t<D>&) const -> real_t {
       return ZERO;
     }
 
@@ -213,7 +213,7 @@ namespace metric {
      * dr derivative of radial component of shift vector
      * @param x coordinate array in code units
      */
-    Inline auto dr_beta1(const coord_t<D>& x) const -> real_t {
+    Inline auto dr_beta1(const coord_t<D>&) const -> real_t {
       return ZERO;
     }
 
@@ -221,7 +221,7 @@ namespace metric {
      * dtheta derivative of radial component of shift vector
      * @param x coordinate array in code units
      */
-    Inline auto dt_beta1(const coord_t<D>& x) const -> real_t {
+    Inline auto dt_beta1(const coord_t<D>&) const -> real_t {
       return ZERO;
     }
 
@@ -229,7 +229,7 @@ namespace metric {
      * dr derivative of h^11
      * @param x coordinate array in code units
      */
-    Inline auto dr_h11(const coord_t<D>& x) const -> real_t {
+    Inline auto dr_h11(const coord_t<D>&) const -> real_t {
       return ZERO;
     }
 
@@ -239,7 +239,6 @@ namespace metric {
      */
     Inline auto dr_h22(const coord_t<D>& x) const -> real_t {
       const real_t r { x[0] * dr + x1_min };
-      const real_t theta { x[1] * dtheta + x2_min };
       return -TWO / CUBE(r) * SQR(dtheta_inv) * dr;
     }
 
@@ -257,7 +256,7 @@ namespace metric {
      * dr derivative of h^13
      * @param x coordinate array in code units
      */
-    Inline auto dr_h13(const coord_t<D>& x) const -> real_t {
+    Inline auto dr_h13(const coord_t<D>&) const -> real_t {
       return ZERO;
     }
 
@@ -265,7 +264,7 @@ namespace metric {
      * dtheta derivative of h^11
      * @param x coordinate array in code units
      */
-    Inline auto dt_h11(const coord_t<D>& x) const -> real_t {
+    Inline auto dt_h11(const coord_t<D>&) const -> real_t {
       return ZERO;
     }
 
@@ -273,7 +272,7 @@ namespace metric {
      * dtheta derivative of h^22
      * @param x coordinate array in code units
      */
-    Inline auto dt_h22(const coord_t<D>& x) const -> real_t {
+    Inline auto dt_h22(const coord_t<D>&) const -> real_t {
       return ZERO;
     }
 
@@ -291,7 +290,7 @@ namespace metric {
      * dtheta derivative of h^13
      * @param x coordinate array in code units
      */
-    Inline auto dt_h13(const coord_t<D>& x) const -> real_t {
+    Inline auto dt_h13(const coord_t<D>&) const -> real_t {
       return ZERO;
     }
 

--- a/src/metrics/kerr_schild_0.h
+++ b/src/metrics/kerr_schild_0.h
@@ -34,9 +34,9 @@ namespace metric {
     static_assert(D != Dim::_3D, "3D kerr_schild_0 not fully implemented");
 
   private:
+    const real_t a, rg_, rh_;
     const real_t dr, dtheta, dphi;
     const real_t dr_inv, dtheta_inv, dphi_inv;
-    const real_t a, rg_, rh_;
 
   public:
     static constexpr const char* Label { "kerr_schild_0" };

--- a/src/metrics/qkerr_schild.h
+++ b/src/metrics/qkerr_schild.h
@@ -90,7 +90,7 @@ namespace metric {
       , dphi { (x3_max - phi_min) / nx3 }
       , dchi_inv { ONE / dchi }
       , deta_inv { ONE / deta }
-      , dphi_inv { ONE / dphi } 
+      , dphi_inv { ONE / dphi }
       , small_angle { eta2theta(HALF * deta) < constant::SMALL_ANGLE } {
       set_dxMin(find_dxMin());
     }
@@ -509,22 +509,22 @@ namespace metric {
      */
     Inline auto polar_area(real_t x1) const -> real_t {
       if constexpr (D != Dim::_1D) {
-        if (small_angle) { 
+        if (small_angle) {
           const real_t dtheta = eta2theta(HALF * deta);
           return dchi * math::exp(x1 * dchi + chi_min) *
-                (SQR(r0 + math::exp(x1 * dchi + chi_min)) + SQR(a)) *
-                math::sqrt(
-                  ONE + TWO * (r0 + math::exp(x1 * dchi + chi_min)) /
-                          (SQR(r0 + math::exp(x1 * dchi + chi_min)) + SQR(a))) *
-                (static_cast<real_t>(48) - SQR(dtheta)) * SQR(dtheta) /
+                 (SQR(r0 + math::exp(x1 * dchi + chi_min)) + SQR(a)) *
+                 math::sqrt(
+                   ONE + TWO * (r0 + math::exp(x1 * dchi + chi_min)) /
+                           (SQR(r0 + math::exp(x1 * dchi + chi_min)) + SQR(a))) *
+                 (static_cast<real_t>(48) - SQR(dtheta)) * SQR(dtheta) /
                  static_cast<real_t>(384);
         } else {
           return dchi * math::exp(x1 * dchi + chi_min) *
-                (SQR(r0 + math::exp(x1 * dchi + chi_min)) + SQR(a)) *
-                math::sqrt(
-                  ONE + TWO * (r0 + math::exp(x1 * dchi + chi_min)) /
-                          (SQR(r0 + math::exp(x1 * dchi + chi_min)) + SQR(a))) *
-                (ONE - math::cos(eta2theta(HALF * deta)));
+                 (SQR(r0 + math::exp(x1 * dchi + chi_min)) + SQR(a)) *
+                 math::sqrt(
+                   ONE + TWO * (r0 + math::exp(x1 * dchi + chi_min)) /
+                           (SQR(r0 + math::exp(x1 * dchi + chi_min)) + SQR(a))) *
+                 (ONE - math::cos(eta2theta(HALF * deta)));
         }
       }
     }

--- a/src/output/checkpoint.h
+++ b/src/output/checkpoint.h
@@ -68,7 +68,8 @@ namespace checkpoint {
     }
 
     [[nodiscard]]
-    auto written() const -> const std::vector<std::pair<std::string, std::string>>& {
+    auto written() const
+      -> const std::vector<std::pair<std::string, std::string>>& {
       return m_written;
     }
 

--- a/src/output/stats.cpp
+++ b/src/output/stats.cpp
@@ -81,11 +81,8 @@ namespace stats {
     CallOnce(
       [this](auto& fname, auto& stat_writers) {
         std::fstream StatsOut(fname, std::fstream::out | std::fstream::app);
-        StatsOut << std::setw(io_precision + 8)
-                 << "step"
-                 << ","
-                 << std::setw(io_precision + 8)
-                 << "time"
+        StatsOut << std::setw(io_precision + 8) << "step"
+                 << "," << std::setw(io_precision + 8) << "time"
                  << ",";
         for (const auto& stat : stat_writers) {
           if (stat.is_vector()) {

--- a/src/output/stats.h
+++ b/src/output/stats.h
@@ -193,9 +193,7 @@ namespace stats {
           [this](auto&& fname, auto&& value) {
             std::fstream StatsOut(fname, std::fstream::out | std::fstream::app);
             StatsOut << std::setw(io_precision + 8)
-                     << std::setprecision(io_precision)
-                     << value
-                     << ",";
+                     << std::setprecision(io_precision) << value << ",";
             StatsOut.close();
           },
           m_fname,

--- a/src/output/utils/interpret_prompt.h
+++ b/src/output/utils/interpret_prompt.h
@@ -26,8 +26,8 @@ namespace out {
 
   auto InterpretSpecies(const std::string&) -> std::vector<spidx_t>;
 
-  auto InterpretComponents(
-    const std::vector<std::string>&) -> std::vector<std::vector<unsigned short>>;
+  auto InterpretComponents(const std::vector<std::string>&)
+    -> std::vector<std::vector<unsigned short>>;
 
 } // namespace out
 


### PR DESCRIPTION
This PR adds a support for the user-provided emission policy defined in the problem generator.

Enabled, by specifying:

```toml
[[particles.species]]
  emission = "custom"
```

and providing a corresponding `PGen::EmissionPolicy` function which returns the custom emission policy.

Example added in `pgens/examples/custom_emission`.