### PR TITLE
Fix particle ID counter in writing checkpoint

### DIFF
--- a/src/framework/containers/particles_io.cpp
+++ b/src/framework/containers/particles_io.cpp
@@ -641,7 +641,7 @@ namespace ntt {
     out::WriteVariable<npart_t>(io,
                                 writer,
                                 fmt::format("s%d_counter", index()),
-                                npart(),
+                                counter(),
                                 domains_total,
                                 domains_offset);
 


### PR DESCRIPTION
### Bug description
When writing checkpoint with particle tracking enabled, the particle counter is mistakenly saved with `npart()`  (ln. 641-646 of framework/containers/particles_io.cpp)

```
out::WriteVariable<npart_t>(io,
                                writer,
                                fmt::format("s%d_counter", index()),
                                npart(),
                                domains_total,
                                domains_offset);
```
So the counter in the checkpoint is the number of active particles in the domain, which is not equal to the true counter. As a result multiple particles will have the same ID after restarting from checkpoint. 

### Suggested fix
Substituting `npart()` with `counter()`. 

The fix is tested on 2D shock setup with tracking enabled. 