### PR TITLE
Port: Async ADIOS2 write and option to choose aggregators per node

### DIFF
--- a/input.example.toml
+++ b/input.example.toml
@@ -496,6 +496,12 @@
   #   @default: true
   #   @deprecated: starting v1.3.0
   separate_files = ""
+  # Number of ADIOS2 aggregators per node
+  #   @type: uint 
+  #   @default: 0
+  #   @note: Set to either MPI ranks/node or NICs/node for best performance
+  #          If set to 0, will use ADIOS2 default
+  aggregators_per_node = 0
 
   [output.fields]
     # Toggle for the field output
@@ -667,6 +673,12 @@
   #   @type: string
   #   @default: inherit `write_path`
   read_path = ""
+  # Number of ADIOS2 aggregators per node
+  #   @type: uint 
+  #   @default: 0
+  #   @note: Set to either MPI ranks/node or NICs/node for best performance
+  #          If set to 0, will use ADIOS2 default
+  aggregators_per_node = 0
 
   # @inferred:
   # - is_resuming

--- a/input.example.toml
+++ b/input.example.toml
@@ -496,12 +496,6 @@
   #   @default: true
   #   @deprecated: starting v1.3.0
   separate_files = ""
-  # Number of ADIOS2 aggregators per node
-  #   @type: uint 
-  #   @default: 0
-  #   @note: Set to either MPI ranks/node or NICs/node for best performance
-  #          If set to 0, will use ADIOS2 default
-  aggregators_per_node = 0
 
   [output.fields]
     # Toggle for the field output
@@ -673,12 +667,6 @@
   #   @type: string
   #   @default: inherit `write_path`
   read_path = ""
-  # Number of ADIOS2 aggregators per node
-  #   @type: uint 
-  #   @default: 0
-  #   @note: Set to either MPI ranks/node or NICs/node for best performance
-  #          If set to 0, will use ADIOS2 default
-  aggregators_per_node = 0
 
   # @inferred:
   # - is_resuming
@@ -693,6 +681,25 @@
   #     @brief: Time of the checkpoint used to resume
   #     @type: float
   #     @from: automatically determined during restart
+
+[adios2]
+  # ADIOS2 BP5 tuning, applied to both [output] and [checkpoint] writers
+  # Number of ADIOS2 aggregators per node
+  #   @type: uint
+  #   @default: 0
+  #   @note: Set to either MPI ranks/node or NICs/node for best performance
+  #          If set to 0, will use ADIOS2 default (one aggregator per node)
+  aggregators_per_node = 0
+  # Maximum shared-memory segment size per node, in bytes (BP5 MaxShmSize)
+  #   @type: uint
+  #   @default: 4294967296
+  #   @note: Lower this on memory-constrained nodes; matches ADIOS2's default
+  max_shm_size = 4294967296
+  # Internal serialization buffer chunk size, in bytes (BP5 BufferChunkSize)
+  #   @type: uint
+  #   @default: 16777216
+  #   @note: Scales with per-rank output volume; matches ADIOS2's default
+  buffer_chunk_size = 16777216
 
 [diagnostics]
   # Number of timesteps between diagnostic logs

--- a/src/framework/domain/metadomain_chckpt.cpp
+++ b/src/framework/domain/metadomain_chckpt.cpp
@@ -63,7 +63,8 @@ namespace ntt {
       params.template get<timestep_t>("checkpoint.interval"),
       params.template get<simtime_t>("checkpoint.interval_time"),
       params.template get<int>("checkpoint.keep"),
-      params.template get<std::string>("checkpoint.walltime"));
+      params.template get<std::string>("checkpoint.walltime"),
+      params.template get<int>("checkpoint.aggregators_per_node"));
     if (g_checkpoint_writer.enabled()) {
       local_domain->fields.CheckpointDeclare(g_checkpoint_writer.io(),
                                              loc_shape_with_ghosts,

--- a/src/framework/domain/metadomain_chckpt.cpp
+++ b/src/framework/domain/metadomain_chckpt.cpp
@@ -64,7 +64,10 @@ namespace ntt {
       params.template get<simtime_t>("checkpoint.interval_time"),
       params.template get<int>("checkpoint.keep"),
       params.template get<std::string>("checkpoint.walltime"),
-      params.template get<int>("checkpoint.aggregators_per_node"));
+      out::Bp5Tuning {
+        params.template get<int>("adios2.aggregators_per_node"),
+        params.template get<std::size_t>("adios2.max_shm_size"),
+        params.template get<std::size_t>("adios2.buffer_chunk_size") });
     if (g_checkpoint_writer.enabled()) {
       local_domain->fields.CheckpointDeclare(g_checkpoint_writer.io(),
                                              loc_shape_with_ghosts,
@@ -270,8 +273,8 @@ namespace ntt {
     // Phase 1: read all subdomain metadata to detect size changes
     std::vector<std::vector<ncells_t>> saved_ncells(g_ndomains,
                                                     std::vector<ncells_t>(M::Dim));
-    std::vector<boundaries_t<real_t>>  saved_extents(g_ndomains);
-    boundaries_t<real_t>               global_extent;
+    std::vector<boundaries_t<real_t>> saved_extents(g_ndomains);
+    boundaries_t<real_t>              global_extent;
     for (auto d { 0u }; d < M::Dim; ++d) {
       global_extent.emplace_back(std::numeric_limits<real_t>::max(),
                                  std::numeric_limits<real_t>::lowest());

--- a/src/framework/domain/metadomain_io.cpp
+++ b/src/framework/domain/metadomain_io.cpp
@@ -62,10 +62,13 @@ namespace ntt {
       }
     }
 
-    g_writer.init(ptr_adios,
-                  params.template get<std::string>("output.format"),
-                  params.template get<std::string>("simulation.name"),
-                  params.template get<int>("output.aggregators_per_node"));
+    g_writer.init(
+      ptr_adios,
+      params.template get<std::string>("output.format"),
+      params.template get<std::string>("simulation.name"),
+      { params.template get<int>("adios2.aggregators_per_node"),
+        params.template get<std::size_t>("adios2.max_shm_size"),
+        params.template get<std::size_t>("adios2.buffer_chunk_size") });
     g_writer.defineMeshLayout(glob_shape_with_ghosts,
                               off_ncells_with_ghosts,
                               loc_shape_with_ghosts,
@@ -358,21 +361,21 @@ namespace ntt {
       l_subdomain_indices().size() != 1,
       "Output for now is only supported for one subdomain per rank",
       HERE);
-    const auto write_fields = params.template get<bool>(
-                                "output.fields.enable") and
-                              g_writer.shouldWrite("fields",
-                                                   finished_step,
-                                                   finished_time);
+    const auto write_fields    = params.template get<bool>(
+                                   "output.fields.enable") and
+                                 g_writer.shouldWrite("fields",
+                                                      finished_step,
+                                                      finished_time);
     const auto write_particles = params.template get<bool>(
                                    "output.particles.enable") and
                                  g_writer.shouldWrite("particles",
                                                       finished_step,
                                                       finished_time);
-    const auto write_spectra = params.template get<bool>(
-                                 "output.spectra.enable") and
-                               g_writer.shouldWrite("spectra",
-                                                    finished_step,
-                                                    finished_time);
+    const auto write_spectra   = params.template get<bool>(
+                                   "output.spectra.enable") and
+                                 g_writer.shouldWrite("spectra",
+                                                      finished_step,
+                                                      finished_time);
     const auto extension = params.template get<std::string>("output.format");
     if (not(write_fields or write_particles or write_spectra) and
         extension != "disabled") {
@@ -852,7 +855,7 @@ namespace ntt {
               // u^i != h^{ij} u_j
               const real_t    u_0_cov { metric.u_0(x_Code,
                                                    { ux1(p), ux2(p), ux3(p) },
-                                                (is_massive) ? ONE : ZERO) };
+                                                   (is_massive) ? ONE : ZERO) };
               vec_t<Dim::_4D> u_cntrv_4d { ZERO };
               metric.template transform_4d<Idx::D, Idx::U>(
                 x_Code,

--- a/src/framework/domain/metadomain_io.cpp
+++ b/src/framework/domain/metadomain_io.cpp
@@ -64,7 +64,8 @@ namespace ntt {
 
     g_writer.init(ptr_adios,
                   params.template get<std::string>("output.format"),
-                  params.template get<std::string>("simulation.name"));
+                  params.template get<std::string>("simulation.name"),
+                  params.template get<int>("output.aggregators_per_node"));
     g_writer.defineMeshLayout(glob_shape_with_ghosts,
                               off_ncells_with_ghosts,
                               loc_shape_with_ghosts,

--- a/src/framework/parameters/output.cpp
+++ b/src/framework/parameters/output.cpp
@@ -19,14 +19,10 @@ namespace ntt {
 
     void Output::read(Dimension dim, std::size_t nspec, const toml::value& toml_data) {
       format = toml::find_or(toml_data, "output", "format", defaults::output::format);
-      aggregators_per_node = toml::find_or<int>(toml_data,
-                                                "output",
-                                                "aggregators_per_node",
-                                                0);
       global_interval      = toml::find_or(toml_data,
-                                      "output",
-                                      "interval",
-                                      defaults::output::interval);
+                                           "output",
+                                           "interval",
+                                           defaults::output::interval);
       global_interval_time = toml::find_or<simtime_t>(toml_data,
                                                       "output",
                                                       "interval_time",
@@ -38,12 +34,12 @@ namespace ntt {
 
       categories.emplace();
       for (const auto& category : { "fields", "particles", "spectra", "stats" }) {
-        const auto q_int               = toml::find_or<timestep_t>(toml_data,
-                                                     "output",
-                                                     category,
-                                                     "interval",
-                                                     0);
-        const auto q_int_time          = toml::find_or<simtime_t>(toml_data,
+        const auto q_int      = toml::find_or<timestep_t>(toml_data,
+                                                          "output",
+                                                          category,
+                                                          "interval",
+                                                          0);
+        const auto q_int_time = toml::find_or<simtime_t>(toml_data,
                                                          "output",
                                                          category,
                                                          "interval_time",
@@ -64,10 +60,10 @@ namespace ntt {
 
       /* Fields --------------------------------------------------------------- */
       const auto flds_out        = toml::find_or(toml_data,
-                                          "output",
-                                          "fields",
-                                          "quantities",
-                                          std::vector<std::string> {});
+                                                 "output",
+                                                 "fields",
+                                                 "quantities",
+                                                 std::vector<std::string> {});
       const auto custom_flds_out = toml::find_or(toml_data,
                                                  "output",
                                                  "fields",
@@ -79,10 +75,10 @@ namespace ntt {
       fields_quantities        = flds_out;
       fields_custom_quantities = custom_flds_out;
       fields_mom_smooth        = toml::find_or(toml_data,
-                                        "output",
-                                        "fields",
-                                        "mom_smooth",
-                                        defaults::output::mom_smooth);
+                                               "output",
+                                               "fields",
+                                               "mom_smooth",
+                                               defaults::output::mom_smooth);
       fields_downsampling.emplace();
       try {
         auto field_dwn_ = toml::find<std::vector<unsigned int>>(toml_data,
@@ -129,35 +125,35 @@ namespace ntt {
                                         "species",
                                         all_specs);
       particles_stride  = toml::find_or(toml_data,
-                                       "output",
-                                       "particles",
-                                       "stride",
-                                       defaults::output::prtl_stride);
+                                        "output",
+                                        "particles",
+                                        "stride",
+                                        defaults::output::prtl_stride);
 
       /* Spectra -------------------------------------------------------------- */
       spectra_e_min    = toml::find_or(toml_data,
-                                    "output",
-                                    "spectra",
-                                    "e_min",
-                                    defaults::output::spec_emin);
+                                       "output",
+                                       "spectra",
+                                       "e_min",
+                                       defaults::output::spec_emin);
       spectra_e_max    = toml::find_or(toml_data,
-                                    "output",
-                                    "spectra",
-                                    "e_max",
-                                    defaults::output::spec_emax);
+                                       "output",
+                                       "spectra",
+                                       "e_max",
+                                       defaults::output::spec_emax);
       spectra_log_bins = toml::find_or(toml_data,
                                        "output",
                                        "spectra",
                                        "log_bins",
                                        defaults::output::spec_log);
       spectra_n_bins   = toml::find_or(toml_data,
-                                     "output",
-                                     "spectra",
-                                     "n_bins",
-                                     defaults::output::spec_nbins);
+                                       "output",
+                                       "spectra",
+                                       "n_bins",
+                                       defaults::output::spec_nbins);
 
       /* Stats ---------------------------------------------------------------- */
-      stats_quantities        = toml::find_or(toml_data,
+      stats_quantities = toml::find_or(toml_data,
                                        "output",
                                        "stats",
                                        "quantities",
@@ -183,7 +179,6 @@ namespace ntt {
 
     void Output::setParams(SimulationParams* params) const {
       params->set("output.format", format.value());
-      params->set("output.aggregators_per_node", aggregators_per_node.value());
       params->set("output.interval", global_interval.value());
       params->set("output.interval_time", global_interval_time.value());
       for (const auto& [category, cat_params] : categories.value()) {

--- a/src/framework/parameters/output.cpp
+++ b/src/framework/parameters/output.cpp
@@ -19,6 +19,10 @@ namespace ntt {
 
     void Output::read(Dimension dim, std::size_t nspec, const toml::value& toml_data) {
       format = toml::find_or(toml_data, "output", "format", defaults::output::format);
+      aggregators_per_node = toml::find_or<int>(toml_data,
+                                                "output",
+                                                "aggregators_per_node",
+                                                0);
       global_interval      = toml::find_or(toml_data,
                                       "output",
                                       "interval",
@@ -179,6 +183,7 @@ namespace ntt {
 
     void Output::setParams(SimulationParams* params) const {
       params->set("output.format", format.value());
+      params->set("output.aggregators_per_node", aggregators_per_node.value());
       params->set("output.interval", global_interval.value());
       params->set("output.interval_time", global_interval_time.value());
       for (const auto& [category, cat_params] : categories.value()) {

--- a/src/framework/parameters/output.h
+++ b/src/framework/parameters/output.h
@@ -35,7 +35,6 @@ namespace ntt {
 
     struct Output {
       std::optional<std::string> format;
-      std::optional<int>         aggregators_per_node;
 
       std::optional<timestep_t> global_interval;
       std::optional<simtime_t>  global_interval_time;

--- a/src/framework/parameters/output.h
+++ b/src/framework/parameters/output.h
@@ -35,6 +35,7 @@ namespace ntt {
 
     struct Output {
       std::optional<std::string> format;
+      std::optional<int>         aggregators_per_node;
 
       std::optional<timestep_t> global_interval;
       std::optional<simtime_t>  global_interval_time;

--- a/src/framework/parameters/parameters.cpp
+++ b/src/framework/parameters/parameters.cpp
@@ -126,7 +126,7 @@ namespace ntt {
     set("grid.boundaries.particles", prtl_bc);
 
     /* [particles] ---------------------------------------------------------- */
-    const auto species_tab               = toml::find_or<toml::array>(toml_data,
+    const auto species_tab = toml::find_or<toml::array>(toml_data,
                                                         "particles",
                                                         "species",
                                                         toml::array {});
@@ -193,8 +193,23 @@ namespace ntt {
     set("checkpoint.write_path", checkpoint_write_path);
     set("checkpoint.read_path",
         toml::find_or(toml_data, "checkpoint", "read_path", checkpoint_write_path));
-    set("checkpoint.aggregators_per_node",
-        toml::find_or<int>(toml_data, "checkpoint", "aggregators_per_node", 0));
+
+    /* [adios2] ------------------------------------------------------------- */
+    set("adios2.aggregators_per_node",
+        toml::find_or<int>(toml_data,
+                           "adios2",
+                           "aggregators_per_node",
+                           defaults::adios::aggregators_per_node));
+    set("adios2.max_shm_size",
+        toml::find_or<std::size_t>(toml_data,
+                                   "adios2",
+                                   "max_shm_size",
+                                   defaults::adios::max_shm_size));
+    set("adios2.buffer_chunk_size",
+        toml::find_or<std::size_t>(toml_data,
+                                   "adios2",
+                                   "buffer_chunk_size",
+                                   defaults::adios::buffer_chunk_size));
 
     /* [diagnostics] -------------------------------------------------------- */
     set("diagnostics.interval",

--- a/src/framework/parameters/parameters.cpp
+++ b/src/framework/parameters/parameters.cpp
@@ -193,6 +193,8 @@ namespace ntt {
     set("checkpoint.write_path", checkpoint_write_path);
     set("checkpoint.read_path",
         toml::find_or(toml_data, "checkpoint", "read_path", checkpoint_write_path));
+    set("checkpoint.aggregators_per_node",
+        toml::find_or<int>(toml_data, "checkpoint", "aggregators_per_node", 0));
 
     /* [diagnostics] -------------------------------------------------------- */
     set("diagnostics.interval",

--- a/src/global/defaults.h
+++ b/src/global/defaults.h
@@ -92,6 +92,15 @@ namespace ntt::defaults {
     const std::string log_level = "VERBOSE";
   } // namespace diag
 
+  namespace adios {
+    // BP5 tuning for large-scale parallel filesystems. Values mirror ADIOS2's
+    // own built-in defaults; aggregators_per_node == 0 leaves the default of
+    // one aggregator per node in place.
+    const int         aggregators_per_node = 0;
+    const std::size_t max_shm_size         = 4294967296ull; // 4 GiB
+    const std::size_t buffer_chunk_size    = 16777216ull;   // 16 MiB
+  } // namespace adios
+
   namespace gca {
     const real_t EovrB_max = 0.9;
   } // namespace gca

--- a/src/output/checkpoint.cpp
+++ b/src/output/checkpoint.cpp
@@ -19,13 +19,13 @@
 
 namespace checkpoint {
 
-  void Writer::init(adios2::ADIOS*     ptr_adios,
-                    const path_t&      checkpoint_root,
-                    timestep_t         interval,
-                    simtime_t          interval_time,
-                    int                keep,
-                    const std::string& walltime,
-                    int                aggregators_per_node) {
+  void Writer::init(adios2::ADIOS*        ptr_adios,
+                    const path_t&         checkpoint_root,
+                    timestep_t            interval,
+                    simtime_t             interval_time,
+                    int                   keep,
+                    const std::string&    walltime,
+                    const out::Bp5Tuning& bp5) {
     m_keep            = keep;
     m_checkpoint_root = checkpoint_root;
     m_enabled         = keep != 0;
@@ -39,21 +39,8 @@ namespace checkpoint {
     m_io = p_adios->DeclareIO("Entity::Checkpoint");
     m_io.SetEngine("BPFile");
 
-    // BP5 tuning for DAOS/Lustre at scale; matches writer.cpp::Writer::init.
-    // Per-node aggregator count scales with the NIC layout (Aurora: 8/node);
-    // 0 keeps ADIOS2's default of one per node.
-    {
-      const auto num_agg = std::to_string(
-        out::total_aggregators(aggregators_per_node));
-      m_io.SetParameter("AggregationType", "TwoLevelShm");
-      m_io.SetParameter("NumAggregators", num_agg);
-      m_io.SetParameter("NumSubFiles", num_agg);
-      m_io.SetParameter("BufferChunkSize", "16777216");
-      m_io.SetParameter("MaxShmSize", "4294967296");
-      m_io.SetParameter("AsyncOpen", "true");
-      m_io.SetParameter("AsyncWrite", "true");
-      m_io.SetParameter("OpenTimeoutSecs", "600");
-    }
+    // Shared BP5 tuning, identical to out::Writer::init.
+    out::applyBp5Tuning(m_io, "BPFile", bp5);
 
     m_io.DefineVariable<timestep_t>("Step");
     m_io.DefineVariable<simtime_t>("Time");
@@ -83,7 +70,7 @@ namespace checkpoint {
       const auto filename = m_checkpoint_root / fmt::format("step-%08lu.bp", step);
       const auto metafilename = m_checkpoint_root /
                                 fmt::format("meta-%08lu.toml", step);
-      m_writer = m_io.Open(filename, adios2::Mode::Write);
+      m_writer                = m_io.Open(filename, adios2::Mode::Write);
       m_written.emplace_back(filename, metafilename);
       logger::Checkpoint(fmt::format("Writing checkpoint to %s and %s",
                                      filename.c_str(),

--- a/src/output/checkpoint.cpp
+++ b/src/output/checkpoint.cpp
@@ -7,6 +7,8 @@
 #include "utils/formatting.h"
 #include "utils/log.h"
 
+#include "output/writer.h"
+
 #include <Kokkos_Core.hpp>
 #include <adios2.h>
 
@@ -22,7 +24,8 @@ namespace checkpoint {
                     timestep_t         interval,
                     simtime_t          interval_time,
                     int                keep,
-                    const std::string& walltime) {
+                    const std::string& walltime,
+                    int                aggregators_per_node) {
     m_keep            = keep;
     m_checkpoint_root = checkpoint_root;
     m_enabled         = keep != 0;
@@ -35,6 +38,22 @@ namespace checkpoint {
 
     m_io = p_adios->DeclareIO("Entity::Checkpoint");
     m_io.SetEngine("BPFile");
+
+    // BP5 tuning for DAOS/Lustre at scale; matches writer.cpp::Writer::init.
+    // Per-node aggregator count scales with the NIC layout (Aurora: 8/node);
+    // 0 keeps ADIOS2's default of one per node.
+    {
+      const auto num_agg = std::to_string(
+        out::total_aggregators(aggregators_per_node));
+      m_io.SetParameter("AggregationType", "TwoLevelShm");
+      m_io.SetParameter("NumAggregators", num_agg);
+      m_io.SetParameter("NumSubFiles", num_agg);
+      m_io.SetParameter("BufferChunkSize", "16777216");
+      m_io.SetParameter("MaxShmSize", "4294967296");
+      m_io.SetParameter("AsyncOpen", "true");
+      m_io.SetParameter("AsyncWrite", "true");
+      m_io.SetParameter("OpenTimeoutSecs", "600");
+    }
 
     m_io.DefineVariable<timestep_t>("Step");
     m_io.DefineVariable<simtime_t>("Time");

--- a/src/output/checkpoint.h
+++ b/src/output/checkpoint.h
@@ -45,12 +45,15 @@ namespace checkpoint {
 
     ~Writer() = default;
 
+    // aggregators_per_node: BP5 aggregator count per node (one per NIC is a good target)
+    // 0 leaves the ADIOS2 default.
     void init(adios2::ADIOS*,
               const path_t&,
               timestep_t,
               simtime_t,
               int,
-              const std::string& = "");
+              const std::string& = "",
+              int                aggregators_per_node = 0);
 
     auto shouldSave(timestep_t, simtime_t) -> bool;
 

--- a/src/output/checkpoint.h
+++ b/src/output/checkpoint.h
@@ -16,6 +16,8 @@
 
 #include "utils/tools.h"
 
+#include "output/writer.h"
+
 #include <adios2.h>
 
 #include <string>
@@ -45,15 +47,13 @@ namespace checkpoint {
 
     ~Writer() = default;
 
-    // aggregators_per_node: BP5 aggregator count per node (one per NIC is a good target)
-    // 0 leaves the ADIOS2 default.
     void init(adios2::ADIOS*,
               const path_t&,
               timestep_t,
               simtime_t,
               int,
-              const std::string& = "",
-              int                aggregators_per_node = 0);
+              const std::string&    = "",
+              const out::Bp5Tuning& = {});
 
     auto shouldSave(timestep_t, simtime_t) -> bool;
 

--- a/src/output/writer.cpp
+++ b/src/output/writer.cpp
@@ -41,11 +41,7 @@ namespace out {
     int      world_size = 1, local_size = 1;
     MPI_Comm shm;
     MPI_Comm_size(MPI_COMM_WORLD, &world_size);
-    MPI_Comm_split_type(MPI_COMM_WORLD,
-                        MPI_COMM_TYPE_SHARED,
-                        0,
-                        MPI_INFO_NULL,
-                        &shm);
+    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &shm);
     MPI_Comm_size(shm, &local_size);
     MPI_Comm_free(&shm);
     num_nodes = (local_size > 0) ? (world_size / local_size) : 1;
@@ -53,10 +49,32 @@ namespace out {
     return std::max(1, num_nodes * aggregators_per_node);
   }
 
+  void applyBp5Tuning(adios2::IO&        io,
+                      const std::string& engine,
+                      const Bp5Tuning&   bp5) {
+    // BP5 tuning for large-scale parallel filesystems.
+    // Per-node aggregator count scales with the NIC layout;
+    // aggregators_per_node == 0 leaves the ADIOS2 default (one per node).
+    const auto eng = fmt::toLower(engine);
+    if (eng != "bpfile" && eng != "bp5") {
+      return;
+    }
+    const auto num_agg = std::to_string(
+      total_aggregators(bp5.aggregators_per_node));
+    io.SetParameter("AggregationType", "TwoLevelShm");
+    io.SetParameter("NumAggregators", num_agg);
+    io.SetParameter("NumSubFiles", num_agg);
+    io.SetParameter("BufferChunkSize", std::to_string(bp5.buffer_chunk_size));
+    io.SetParameter("MaxShmSize", std::to_string(bp5.max_shm_size));
+    io.SetParameter("AsyncOpen", "true");
+    io.SetParameter("AsyncWrite", "true");
+    io.SetParameter("OpenTimeoutSecs", "600");
+  }
+
   void Writer::init(adios2::ADIOS*     ptr_adios,
                     const std::string& engine,
                     const std::string& title,
-                    int                aggregators_per_node) {
+                    const Bp5Tuning&   bp5) {
     m_engine = fmt::toLower(engine);
     p_adios  = ptr_adios;
 
@@ -65,20 +83,7 @@ namespace out {
     m_io = p_adios->DeclareIO("Entity::Output");
     m_io.SetEngine(engine);
 
-    // BP5 tuning for large-scale parallel filesystems.
-    // Per-node aggregator count scales with the NIC layout;
-    // pass 0 to leave the ADIOS2 default (one per node) in place.
-    if (m_engine == "bpfile" || m_engine == "bp5") {
-      const auto num_agg = std::to_string(total_aggregators(aggregators_per_node));
-      m_io.SetParameter("AggregationType", "TwoLevelShm");
-      m_io.SetParameter("NumAggregators", num_agg);
-      m_io.SetParameter("NumSubFiles", num_agg);
-      m_io.SetParameter("BufferChunkSize", "16777216");
-      m_io.SetParameter("MaxShmSize", "4294967296"); // ToDo: make tunable?
-      m_io.SetParameter("AsyncOpen", "true");
-      m_io.SetParameter("AsyncWrite", "true");
-      m_io.SetParameter("OpenTimeoutSecs", "600");
-    }
+    applyBp5Tuning(m_io, m_engine, bp5);
 
     m_io.DefineVariable<timestep_t>("Step");
     m_io.DefineVariable<simtime_t>("Time");

--- a/src/output/writer.cpp
+++ b/src/output/writer.cpp
@@ -20,9 +20,11 @@
 #endif
 
 #include <algorithm>
+#include <any>
 #include <cstddef>
 #include <exception>
 #include <filesystem>
+#include <memory>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -30,9 +32,31 @@
 
 namespace out {
 
+  int total_aggregators(int aggregators_per_node) {
+    if (aggregators_per_node <= 0) {
+      return 0;
+    }
+    int num_nodes = 1;
+#if defined(MPI_ENABLED)
+    int      world_size = 1, local_size = 1;
+    MPI_Comm shm;
+    MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+    MPI_Comm_split_type(MPI_COMM_WORLD,
+                        MPI_COMM_TYPE_SHARED,
+                        0,
+                        MPI_INFO_NULL,
+                        &shm);
+    MPI_Comm_size(shm, &local_size);
+    MPI_Comm_free(&shm);
+    num_nodes = (local_size > 0) ? (world_size / local_size) : 1;
+#endif
+    return std::max(1, num_nodes * aggregators_per_node);
+  }
+
   void Writer::init(adios2::ADIOS*     ptr_adios,
                     const std::string& engine,
-                    const std::string& title) {
+                    const std::string& title,
+                    int                aggregators_per_node) {
     m_engine = fmt::toLower(engine);
     p_adios  = ptr_adios;
 
@@ -40,6 +64,21 @@ namespace out {
 
     m_io = p_adios->DeclareIO("Entity::Output");
     m_io.SetEngine(engine);
+
+    // BP5 tuning for large-scale parallel filesystems.
+    // Per-node aggregator count scales with the NIC layout;
+    // pass 0 to leave the ADIOS2 default (one per node) in place.
+    if (m_engine == "bpfile" || m_engine == "bp5") {
+      const auto num_agg = std::to_string(total_aggregators(aggregators_per_node));
+      m_io.SetParameter("AggregationType", "TwoLevelShm");
+      m_io.SetParameter("NumAggregators", num_agg);
+      m_io.SetParameter("NumSubFiles", num_agg);
+      m_io.SetParameter("BufferChunkSize", "16777216");
+      m_io.SetParameter("MaxShmSize", "4294967296"); // ToDo: make tunable?
+      m_io.SetParameter("AsyncOpen", "true");
+      m_io.SetParameter("AsyncWrite", "true");
+      m_io.SetParameter("OpenTimeoutSecs", "600");
+    }
 
     m_io.DefineVariable<timestep_t>("Step");
     m_io.DefineVariable<simtime_t>("Time");
@@ -185,6 +224,7 @@ namespace out {
   template <Dimension D, int N>
   void WriteField(adios2::IO&               io,
                   adios2::Engine&           writer,
+                  std::vector<std::any>&    keepalive,
                   const std::string&        varname,
                   const ndfield_t<D, N>&    field,
                   std::size_t               comp,
@@ -299,7 +339,10 @@ namespace out {
     }
     auto output_field_h = Kokkos::create_mirror_view(output_field);
     Kokkos::deep_copy(output_field_h, output_field);
-    writer.Put(var, output_field_h, adios2::Mode::Sync);
+    writer.Put(var, output_field_h, adios2::Mode::Deferred);
+    // Keep the host mirror (and via Kokkos refcount, its allocation) alive
+    // until EndStep runs the deferred PerformPuts.
+    keepalive.emplace_back(output_field_h);
   }
 
   template <Dimension D, int N>
@@ -315,6 +358,7 @@ namespace out {
     for (auto i { 0u }; i < addresses.size(); ++i) {
       WriteField<D, N>(m_io,
                        m_writer,
+                       m_keepalive,
                        names[i],
                        fld,
                        addresses[i],
@@ -334,7 +378,8 @@ namespace out {
       adios2::Box<adios2::Dims>({ loc_offset }, { array.extent(0) }));
     auto array_h = Kokkos::create_mirror_view(array);
     Kokkos::deep_copy(array_h, array);
-    m_writer.Put<real_t>(var, array_h, adios2::Mode::Sync);
+    m_writer.Put<real_t>(var, array_h, adios2::Mode::Deferred);
+    m_keepalive.emplace_back(array_h);
   }
 
   void Writer::writeSpectrum(const array_t<real_t*>& counts,
@@ -357,14 +402,16 @@ namespace out {
     if (rank == MPI_ROOT_RANK) {
       var.SetSelection(
         adios2::Box<adios2::Dims>({ 0u }, { counts_h_all.extent(0) }));
-      m_writer.Put<real_t>(var, counts_h_all, adios2::Mode::Sync);
+      m_writer.Put<real_t>(var, counts_h_all, adios2::Mode::Deferred);
+      m_keepalive.emplace_back(counts_h_all);
     } else {
       var.SetSelection(adios2::Box<adios2::Dims>({ 0u }, { 0u }));
       m_writer.Put<real_t>(var, nullptr);
     }
 #else
     var.SetSelection(adios2::Box<adios2::Dims>({}, { counts.extent(0) }));
-    m_writer.Put<real_t>(var, counts_h, adios2::Mode::Sync);
+    m_writer.Put<real_t>(var, counts_h, adios2::Mode::Deferred);
+    m_keepalive.emplace_back(counts_h);
 #endif
   }
 
@@ -378,14 +425,16 @@ namespace out {
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     if (rank == MPI_ROOT_RANK) {
       var.SetSelection(adios2::Box<adios2::Dims>({ 0u }, { e_bins_h.extent(0) }));
-      m_writer.Put<real_t>(var, e_bins_h.data(), adios2::Mode::Sync);
+      m_writer.Put<real_t>(var, e_bins_h.data(), adios2::Mode::Deferred);
+      m_keepalive.emplace_back(e_bins_h);
     } else {
       var.SetSelection(adios2::Box<adios2::Dims>({ 0u }, { 0u }));
       m_writer.Put<real_t>(var, nullptr, adios2::Mode::Sync);
     }
 #else
     var.SetSelection(adios2::Box<adios2::Dims>({}, { e_bins_h.extent(0) }));
-    m_writer.Put<real_t>(var, e_bins_h, adios2::Mode::Sync);
+    m_writer.Put<real_t>(var, e_bins_h, adios2::Mode::Deferred);
+    m_keepalive.emplace_back(e_bins_h);
 #endif
   }
 
@@ -399,11 +448,17 @@ namespace out {
     auto xe_h = Kokkos::create_mirror_view(xe);
     Kokkos::deep_copy(xc_h, xc);
     Kokkos::deep_copy(xe_h, xe);
-    m_writer.Put(varc, xc_h, adios2::Mode::Sync);
-    m_writer.Put(vare, xe_h, adios2::Mode::Sync);
+    m_writer.Put(varc, xc_h, adios2::Mode::Deferred);
+    m_writer.Put(vare, xe_h, adios2::Mode::Deferred);
+    m_keepalive.emplace_back(xc_h);
+    m_keepalive.emplace_back(xe_h);
     auto vard = m_io.InquireVariable<std::size_t>(
       "N" + std::to_string(dim + 1) + "l");
-    m_writer.Put(vard, loc_off_sz.data(), adios2::Mode::Sync);
+    // loc_off_sz is a caller-side local; copy into keepalive so the pointer
+    // we hand to ADIOS2 stays valid until EndStep.
+    auto loc_off_sz_copy = std::make_shared<std::vector<std::size_t>>(loc_off_sz);
+    m_writer.Put(vard, loc_off_sz_copy->data(), adios2::Mode::Deferred);
+    m_keepalive.emplace_back(std::move(loc_off_sz_copy));
   }
 
   void Writer::beginWriting(WriteModeTags write_mode,
@@ -466,6 +521,8 @@ namespace out {
     }
     m_active_mode = WriteMode::None;
     m_writer.EndStep();
+    // EndStep flushes all Deferred Put buffers; safe to release keepalive.
+    m_keepalive.clear();
     m_writer.Close();
   }
 
@@ -475,6 +532,7 @@ namespace out {
                                          const std::vector<std::size_t>&);     \
   template void WriteField<D, N>(adios2::IO&,                                  \
                                  adios2::Engine&,                              \
+                                 std::vector<std::any>&,                       \
                                  const std::string&,                           \
                                  const ndfield_t<D, N>&,                       \
                                  std::size_t,                                  \

--- a/src/output/writer.h
+++ b/src/output/writer.h
@@ -32,10 +32,16 @@
   #include <mpi.h>
 #endif
 
+#include <any>
 #include <string>
 #include <vector>
 
 namespace out {
+
+  // Total BP5 aggregator count for the current job = aggregators_per_node *
+  // num_nodes (node count taken from MPI_COMM_TYPE_SHARED). Returns 0 when
+  // aggregators_per_node <= 0, which leaves ADIOS2 on its built-in default.
+  int total_aggregators(int aggregators_per_node);
 
   class Writer {
     adios2::ADIOS* p_adios { nullptr };
@@ -74,6 +80,11 @@ namespace out {
 
     WriteModeTags m_active_mode { WriteMode::None };
 
+    // Buffers handed to ADIOS2 via Mode::Deferred Put. These must remain
+    // valid until EndStep() flushes them, so they are stored here and
+    // released in endWriting() after EndStep returns.
+    std::vector<std::any> m_keepalive;
+
   public:
     Writer() {}
 
@@ -81,7 +92,12 @@ namespace out {
 
     Writer(Writer&&) = default;
 
-    void init(adios2::ADIOS*, const std::string&, const std::string&);
+    // aggregators_per_node: BP5 aggregator count per node (one per NIC is a good target)
+    // 0 leaves the ADIOS2 default.
+    void init(adios2::ADIOS*,
+              const std::string&,
+              const std::string&,
+              int aggregators_per_node = 0);
 
     void setMode(adios2::Mode);
 

--- a/src/output/writer.h
+++ b/src/output/writer.h
@@ -33,15 +33,29 @@
 #endif
 
 #include <any>
+#include <cstddef>
 #include <string>
 #include <vector>
 
 namespace out {
 
+  // BP5 tuning knobs sourced from the [adios2] toml section. Defaults mirror
+  // ADIOS2's own built-ins; aggregators_per_node == 0 leaves the default of
+  // one aggregator per node in place.
+  struct Bp5Tuning {
+    int         aggregators_per_node { 0 };
+    std::size_t max_shm_size { 4294967296ull };
+    std::size_t buffer_chunk_size { 16777216ull };
+  };
+
   // Total BP5 aggregator count for the current job = aggregators_per_node *
   // num_nodes (node count taken from MPI_COMM_TYPE_SHARED). Returns 0 when
   // aggregators_per_node <= 0, which leaves ADIOS2 on its built-in default.
   int total_aggregators(int aggregators_per_node);
+
+  // Apply the [adios2] BP5 tuning to a freshly declared IO whose engine is
+  // BPFile/BP5. A no-op for other engines.
+  void applyBp5Tuning(adios2::IO&, const std::string& engine, const Bp5Tuning&);
 
   class Writer {
     adios2::ADIOS* p_adios { nullptr };
@@ -92,12 +106,10 @@ namespace out {
 
     Writer(Writer&&) = default;
 
-    // aggregators_per_node: BP5 aggregator count per node (one per NIC is a good target)
-    // 0 leaves the ADIOS2 default.
     void init(adios2::ADIOS*,
               const std::string&,
               const std::string&,
-              int aggregators_per_node = 0);
+              const Bp5Tuning& = {});
 
     void setMode(adios2::Mode);
 


### PR DESCRIPTION
ADIOS2 performance improvements from the ALCF Aurora hackathon. This PR implements async ADIOS2 writing, and the option to set the number of aggregators per node.
`aggregators_per_node` should be set either to the number of MPI ranks per node, or the number of NICs per node (e.g. on Aurora with DAOS).
It defaults to `0`, which lets ADIOS2 decide. Typically that means 1 aggregator per node.

We should discuss if `BufferChunkSize` and `MaxShmSize` are worth exposing to the user. See the ADIOS2 docs [here](https://adios2.readthedocs.io/en/latest/advanced/memory_management.html#bp5-buffering).