### PR TITLE
int32 overflow for particle checkpointing fixed

### DIFF
--- a/src/framework/containers/particles_io.cpp
+++ b/src/framework/containers/particles_io.cpp
@@ -130,14 +130,17 @@ namespace ntt {
     }
 
 #if !defined(MPI_ENABLED)
-    const npart_t nout_offset = 0;
-    const npart_t nout_total  = nout;
+    const std::size_t nout_offset = 0;
+    const std::size_t nout_total  = nout;
     (void)domains_total;
     (void)domains_offset;
 #else
-    npart_t nout_offset    = 0;
-    npart_t nout_total     = nout;
-    auto    nout_total_vec = std::vector<npart_t>(domains_total);
+    // global totals/offsets are sums over all ranks and can exceed the
+    // per-rank `npart_t` (uint32_t) range at large problem sizes, so
+    // accumulate them in a 64-bit type
+    std::size_t nout_offset    = 0;
+    std::size_t nout_total     = 0;
+    auto        nout_total_vec = std::vector<npart_t>(domains_total);
     MPI_Allgather(&nout,
                   1,
                   mpi::get_type<npart_t>(),
@@ -145,7 +148,6 @@ namespace ntt {
                   1,
                   mpi::get_type<npart_t>(),
                   MPI_COMM_WORLD);
-    nout_total = 0;
     for (auto r = 0u; r < domains_total; ++r) {
       if (r < domains_offset) {
         nout_offset += nout_total_vec[r];
@@ -442,10 +444,13 @@ namespace ntt {
     set_npart(npart_read);
 
 #if !defined(MPI_ENABLED)
-    const npart_t npart_offset = 0u;
+    const std::size_t npart_offset = 0u;
     (void)domains_total;
 #else
-    npart_t npart_offset = 0u;
+    // global offset is a sum over all ranks and can exceed the per-rank
+    // `npart_t` (uint32_t) range at large problem sizes, so accumulate
+    // it in a 64-bit type
+    std::size_t npart_offset = 0u;
     {
       const auto           npart_send = npart();
       std::vector<npart_t> glob_nparts(domains_total);
@@ -618,8 +623,11 @@ namespace ntt {
       fmt::format("Writing particle checkpoint for species #%d", index()),
       HERE);
 
-    npart_t npart_offset = 0u;
-    npart_t npart_total  = npart();
+    // global totals/offsets are sums over all ranks and can exceed the
+    // per-rank `npart_t` (uint32_t) range at large problem sizes, so
+    // accumulate them in a 64-bit type
+    std::size_t npart_offset = 0u;
+    std::size_t npart_total  = npart();
 
 #if defined(MPI_ENABLED)
     {


### PR DESCRIPTION
- If a simulation has a large amount of particles, npart>2^32-1 (e.g., for a 40 000 x 40 000 simulation with ppc=16) would lead to overflow in `nout_total`, `nout_offset`, `npart_total`, `npart_offset` using `npart_t` during checkpoint writing, corrupting checkpoint data (see screenshot of density field attached). 
- This is fixed by declaring the variables mentioned above as `std::size_t` at `particle_io.cpp`.
- The fix was tested on frontier with 40000x40000 simulation, and now the data is saved correctly.

<img width="683" height="509" alt="Screenshot_20260626_043848" src="https://github.com/user-attachments/assets/e47d168c-add6-41e0-bae0-05394ba3e9cb" />
